### PR TITLE
maintain general structure for chapter summaries

### DIFF
--- a/book/introduction.asc
+++ b/book/introduction.asc
@@ -46,12 +46,12 @@ chapter shows you how to cope if you still have to use a SVN server. We also cov
 import projects from several different systems in case you do convince everyone to make the
 plunge.
 
-Now that you know all about Git and can wield it with power and grace, you can move on to
-*Chapter 10*, which delves into the murky yet beautiful depths of Git internals. Here we will
-discuss how Git stores its objects, what the object model is, details of packfiles, server protocols,
-and more. Throughout the book, we will refer to sections of this chapter in case you feel like
-diving deep at that point; but if you are like me and want to dive into the technical details, you
-may want to read Chapter 10 first. We leave that up to you.
+*Chapter 10* delves into the murky yet beautiful depths of Git internals. Now that you know all 
+about Git and can wield it with power and grace, you can move on to discuss how Git stores its objects,
+what the object model is, details of packfiles, server protocols, and more. Throughout the book,
+we will refer to sections of this chapter in case you feel like diving deep at that point; 
+but if you are like me and want to dive into the technical details, you may want to read Chapter 10 first.
+We leave that up to you.
 
 In *Appendix A* we look at a number of examples of using Git in various specific environments. We cover
 a number of different GUIs and IDE programming environments that you may want to use Git in and what


### PR DESCRIPTION
The chapter summary for 10 is jarring due to prose inserted before the bold chapter number.  This patch attempts to maintain a similar pattern of the previous 9 chapter summaries, removes this discord, and maintains the original content. It may be that this difference is a means to call out the authors desire to read chapter 10 first. in that case maybe some other call out could be employed to prevent the jarring effect.
