### PR TITLE
Correct git log -S syntax

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -249,7 +249,7 @@ Another really helpful filter is the `-S` option which takes a string and only s
 
 [source,console]
 ----
-$ git log --Sfunction_name
+$ git log -Sfunction_name
 ----
 
 The last really useful option to pass to `git log` as a filter is a path.


### PR DESCRIPTION
From the surrounding text, and from trying it out myself, the correct option for git log seems to be -S, not --S.
