### PR TITLE
Update recording-changes for libgit2

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -237,7 +237,7 @@ doc/**/*.txt
 
 [TIP]
 ====
-GitHub maintains a fairly comprehensive list of good `.gitignore` file examples for dozens or projects and languages at https://github.com/github/gitignore[] if you want a starting point for your project.
+GitHub maintains a fairly comprehensive list of good `.gitignore` file examples for dozens of projects and languages at https://github.com/github/gitignore[] if you want a starting point for your project.
 ====
 
 [[_git_diff_staged]]
@@ -273,20 +273,19 @@ To see what you've changed but not yet staged, type `git diff` with no other arg
 ----
 $ git diff
 diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
-index 3cb747f..e445e28 100644
+index 8ebb991..643e24f 100644
 --- a/CONTRIBUTING.md
 +++ b/CONTRIBUTING.md
-@@ -36,6 +36,10 @@ def main
-           @commit.parents[0].parents[0].parents[0]
-         end
-
-+        run_code(x, 'commits 1') do
-+          git.commits.size
-+        end
-+
-         run_code(x, 'commits 2') do
-           log = git.commits('master', 15)
-           log.size
+@@ -65,7 +65,8 @@ branch directly, things can get messy.
+ Please include a nice description of your changes when you submit your PR;
+ if we have to read the whole diff to figure out why you're contributing
+ in the first place, you're less likely to get feedback and have your change
+-merged in.
++merged in. Also, split your changes into comprehensive chunks if you patch is
++longer than a dozen lines.
+ 
+ If you are starting to work on a particular area, feel free to submit a PR
+ that highlights your work in progress (and note in the PR title that it's
 ----
 
 That command compares what is in your working directory with what is in your staging area.
@@ -303,11 +302,8 @@ new file mode 100644
 index 0000000..03902a1
 --- /dev/null
 +++ b/README
-@@ -0,0 +1,4 @@
+@@ -0,0 +1 @@
 +My Project
-+
-+ This is my project and it is amazing.
-+
 ----
 
 It's important to note that `git diff` by itself doesn't show all changes made since your last commit – only changes that are still unstaged.
@@ -318,7 +314,7 @@ For another example, if you stage the `CONTRIBUTING.md` file and then edit it, y
 [source,console]
 ----
 $ git add CONTRIBUTING.md
-$ echo '# test line' >> CONTRIBUTING.md
+$ echo 'test line' >> CONTRIBUTING.md
 $ git status
 On branch master
 Changes to be committed:
@@ -339,13 +335,13 @@ Now you can use `git diff` to see what is still unstaged
 ----
 $ git diff
 diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
-index e445e28..86b2f7c 100644
+index 643e24f..87f08c8 100644
 --- a/CONTRIBUTING.md
 +++ b/CONTRIBUTING.md
-@@ -127,3 +127,4 @@ end
- main()
-
- ##pp Grit::GitRuby.cache_client.stats
+@@ -119,3 +119,4 @@ at the
+ ## Starter Projects
+ 
+ See our [projects list](https://github.com/libgit2/libgit2/blob/development/PROJECTS.md).
 +# test line
 ----
 
@@ -355,20 +351,19 @@ and `git diff --cached` to see what you've staged so far:
 ----
 $ git diff --cached
 diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
-index 3cb747f..e445e28 100644
+index 8ebb991..643e24f 100644
 --- a/CONTRIBUTING.md
 +++ b/CONTRIBUTING.md
-@@ -36,6 +36,10 @@ def main
-          @commit.parents[0].parents[0].parents[0]
-        end
-
-+        run_code(x, 'commits 1') do
-+          git.commits.size
-+        end
-+
-        run_code(x, 'commits 2') do
-          log = git.commits('master', 15)
-          log.size
+@@ -65,7 +65,8 @@ branch directly, things can get messy.
+ Please include a nice description of your changes when you submit your PR;
+ if we have to read the whole diff to figure out why you're contributing
+ in the first place, you're less likely to get feedback and have your change
+-merged in.
++merged in. Also, split your changes into comprehensive chunks if you patch is
++longer than a dozen lines.
+ 
+ If you are starting to work on a particular area, feel free to submit a PR
+ that highlights your work in progress (and note in the PR title that it's
 ----
 
 [[_git_difftool]]
@@ -472,14 +467,15 @@ If you simply remove the file from your working directory, it shows up under the
 
 [source,console]
 ----
-$ rm grit.gemspec
+$ rm PROJECTS.md
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes not staged for commit:
   (use "git add/rm <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
 
-    deleted:    grit.gemspec
+        deleted:    PROJECTS.md
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ----
@@ -488,14 +484,14 @@ Then, if you run `git rm`, it stages the file's removal:
 
 [source,console]
 ----
-$ git rm grit.gemspec
-rm 'grit.gemspec'
+$ git rm PROJECTS.md
+rm 'PROJECTS.md'
 $ git status
 On branch master
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
-    deleted:    grit.gemspec
+    deleted:    PROJECTS.md
 ----
 
 The next time you commit, the file will be gone and no longer tracked.


### PR DESCRIPTION
Here is my take on updating the git basics chapter to fit with the choice of libgit2 as the sample project.
