### PR TITLE
Fix typo: mintues -> minutes.

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -85,7 +85,7 @@ If you didn't want it to be called `serverfix` on the remote, you could instead 
 ====
 If you're using an HTTPS URL to push over, the Git server will ask you for your username and password for authentication. By default it will prompt you on the terminal for this information so the server can tell if you're allowed to push.
 
-If you don't want to type it every single time you push, you can set up a ``credential cache''. The simplest is just to keep it in memory for a few mintues, which you can easily set up by running `git config --global credential.helper cache`.
+If you don't want to type it every single time you push, you can set up a ``credential cache''. The simplest is just to keep it in memory for a few minutes, which you can easily set up by running `git config --global credential.helper cache`.
 
 For more information on the various credential caching options available, see <<_credential_caching>>.
 ====


### PR DESCRIPTION
Fix typo: mintues -> minutes.
