### PR TITLE
Missing hyphen in git-http-backend

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -60,7 +60,7 @@ $ htdigest -c /opt/git/.htpasswd "Git Access" schacon
 
 There are tons of ways to have Apache authenticate users, you'll have to choose and implement one of them. This is just the simplest example we could come up with. You'll also almost certainly want to set this up over SSL so all this data is encrypted.
 
-We don't want to go too far down the rabbit hole of Apache configuration specifics, since you could well be using a different server or have different authenication needs. The idea is that Git comes with a CGI called `git http-backend` that when invoked will do all the negotiation to send and receive data over HTTP. It does not implement any authentication itself, but that can easily be controlled at the layer of the web server that invokes it. You can do this with nearly any CGI-capable web server, so go with the one that you know best.
+We don't want to go too far down the rabbit hole of Apache configuration specifics, since you could well be using a different server or have different authenication needs. The idea is that Git comes with a CGI called `git-http-backend` that when invoked will do all the negotiation to send and receive data over HTTP. It does not implement any authentication itself, but that can easily be controlled at the layer of the web server that invokes it. You can do this with nearly any CGI-capable web server, so go with the one that you know best.
 
 [NOTE]
 ====


### PR DESCRIPTION
Add missing hyphen in the command name.
