### PR TITLE
Fix git's output

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -84,7 +84,7 @@ void loop() {
 }
 
 $ git commit -a -m 'three seconds is better' <5>
-[master 5ca509d] three seconds is better
+[slow-blink 5ca509d] three seconds is better
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 $ git push origin slow-blink <6>


### PR DESCRIPTION
When committing to a branch, git commit prints the branch name, "slow-blink" this time, not master.
