### PR TITLE
Improve subtree merge command line.

### DIFF
--- a/book/07-git-tools/sections/subtree-merges.asc
+++ b/book/07-git-tools/sections/subtree-merges.asc
@@ -66,13 +66,12 @@ $ git pull
 ----
 
 Then, we can merge those changes back into our `master` branch.
-We can use `git merge -s subtree` and it will work fine; but Git will also merge the histories together, which we probably don’t want.
-To pull in the changes and prepopulate the commit message, use the `--squash` and `--no-commit` options as well as the `-s subtree` strategy option:
+To pull in the changes and prepopulate the commit message, use the `--squash` and `--no-commit` options, as well as the recursive merge strategy's `-Xsubtree` option. (The recursive strategy is the default here, but we include it for clarity.)
 
 [source,console]
 ----
 $ git checkout master
-$ git merge --squash -s subtree --no-commit rack_branch
+$ git merge --squash -s recursive -Xsubtree=rack --no-commit rack_branch
 Squash commit -- not updating HEAD
 Automatic merge went well; stopped before committing as requested
 ----


### PR DESCRIPTION
Subtree merge doesn't always work as intended here.

For example, I tried these instructions with two repositories,
repository A, which contained a README file, and repository B, which
contained README and AUTHORS files. I used read-tree to put repository
B into a subdirectory of repository A, then ran the git merge
incantation affected by this patch.

With Git 1.9.1 from the Ubuntu 14.04 repositories, git-merge decided
that the correct subtree of A to merge B into was the root directory
of A, perhaps because the directory structure was similar enough to
satisfy some heuristic.

Replace the subtree strategy with recursive and explicit hint about
where the subtree is, which worked as intended. The output ("Squash
commit [...] as requested") was unchanged.

Signed-off-by: Marti Bolivar mbolivarmullen@gmail.com
