### PR TITLE
Fix link to Git Aliases page

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -721,7 +721,7 @@ Here we can see that we're defining a function in a submodule and calling it in 
 
 ===== Useful Aliases
 
-You may want to set up some aliases for some of these commands as they can be quite long and you can't set configuration options for most of them to make them defaults. We covered setting up Git aliases in [[_git_aliases]], but here is an example of what you may want to set up if you plan on working with submodules in Git a lot.
+You may want to set up some aliases for some of these commands as they can be quite long and you can't set configuration options for most of them to make them defaults. We covered setting up Git aliases in <<_git_aliases>>, but here is an example of what you may want to set up if you plan on working with submodules in Git a lot.
 
 [source,console]
 ----


### PR DESCRIPTION
The link was surrounded with square brackets instead of angled, which resulted in the link simply not appearing.
