### PR TITLE
libgit2: use peel() in the pygit2 example

### DIFF
--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -228,8 +228,9 @@ Our example program:
 [source,python]
 ----
 pygit2.Repository("/path/to/repo") # open repository
-    .head.resolve()                # get a direct ref
-    .get_object().message          # get commit, read message
+    .head                          # get the current branch
+    .peel(pygit2.Commit)           # walk down to the commit
+    .message                       # read the message
 ----
 
 


### PR DESCRIPTION
get_object() is deprecated, and we now have the common peeling mechanism
which we can use to get to the commit more elegantly.
