### PR TITLE
Fix missed include

### DIFF
--- a/book/07-git-tools/1-git-tools.asc
+++ b/book/07-git-tools/1-git-tools.asc
@@ -26,6 +26,8 @@ include::sections/rerere.asc[]
 
 include::sections/debugging.asc[]
 
+include::sections/notes.asc[]
+
 include::sections/submodules.asc[]
 
 include::sections/bundling.asc[]


### PR DESCRIPTION
Looks like this include is missed, as I see reference error in [Appendix C](http://git-scm.com/book/en/v2/Git-Commands-Sharing-and-Updating-Projects#git-push)
