### PR TITLE
Fix broken xref

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -283,7 +283,7 @@ index 8ebb991..643e24f 100644
 -merged in.
 +merged in. Also, split your changes into comprehensive chunks if you patch is
 +longer than a dozen lines.
- 
+
  If you are starting to work on a particular area, feel free to submit a PR
  that highlights your work in progress (and note in the PR title that it's
 ----
@@ -340,7 +340,7 @@ index 643e24f..87f08c8 100644
 +++ b/CONTRIBUTING.md
 @@ -119,3 +119,4 @@ at the
  ## Starter Projects
- 
+
  See our [projects list](https://github.com/libgit2/libgit2/blob/development/PROJECTS.md).
 +# test line
 ----
@@ -361,13 +361,13 @@ index 8ebb991..643e24f 100644
 -merged in.
 +merged in. Also, split your changes into comprehensive chunks if you patch is
 +longer than a dozen lines.
- 
+
  If you are starting to work on a particular area, feel free to submit a PR
  that highlights your work in progress (and note in the PR title that it's
 ----
 
-[[_git_difftool]]
 [NOTE]
+[[_git_difftool]]
 .Git Diff in an External Tool
 ====
 We will continue to use the `git diff` command in various ways throughout the rest of the book. There is another way to look at these diffs if you prefer a graphical or external diff viewing program instead. If you run `git difftool` instead of `git diff`, you can view any of these diffs in software like Araxis, emerge, vimdiff and more. Run `git difftool --tool-help` to see what is available on your system.


### PR DESCRIPTION
Continued from #157. I checked the Atlas logs, and the only non-notes xref that's broken is this one.
