### PR TITLE
Fix 'dummy ours merge strategy' display

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -314,12 +314,12 @@ You can set up an attribute like this:
 database.xml merge=ours
 ----
 
+And then define a dummy `ours` merge strategy with:
+
 [source,console]
 ----
-And then define a dummy `ours` merge strategy with:
-----
-
 $ git config --global merge.ours.driver true
+----
 
 If you merge in the other branch, instead of having merge conflicts with the `database.xml` file, you see something like this:
 


### PR DESCRIPTION
Display the text as text and the command as console source.
