### PR TITLE
Add layout for epub metadata

### DIFF
--- a/theme/epub/layout.html
+++ b/theme/epub/layout.html
@@ -1,0 +1,14 @@
+{{ doctype }}
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="publisher" content="Apress"/>
+    <meta name="author" content="Scott Chacon, Ben Straub"/>
+    <meta name="date" content="2014-11-01"/>
+    <meta name="description" content="Pro Git (Second Edition) is your fully-updated guide to Git and its usage in the modern world."/>
+    <title>{{ title }}</title>
+  </head>
+  <body data-type="book">
+    {{ content }}
+  </body>
+</html>


### PR DESCRIPTION
This addresses the issue of no epub metadata in #150 
