### PR TITLE
Remove a deprecated feature of GitLab

### DIFF
--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -127,6 +127,5 @@ Merge requests and issues are the main units of long-lived discussion in GitLab.
 Each merge request allows a line-by-line discussion of the proposed change (which supports a lightweight kind of code review), as well as a general overall discussion thread.
 Both can be assigned to users, or organized into milestones.
 
-This section has focused mainly on the Git-related parts of GitLab, but it's a fairly mature system, and provides many other features that can help your team work together.
-These include project wikis and system maintenance tools.
+This section is focused mainly on the Git-related features of GitLab, but as a mature project, it provides many other features to help your team work together, such as project wikis and system maintenance tools.
 One benefit to GitLab is that, once the server is set up and running, you'll rarely need to tweak a configuration file or access the server via SSH; most administration and general usage can be accomplished through the in-browser interface.


### PR DESCRIPTION
> We are also removing Wall from projects because we feel that the time needed for developing and keeping bug free is not justified if compared to the usefulness of the feature.
> [GitLab Blog | GitLab 7.0 released with drag and drop images and performance improvements](https://about.gitlab.com/2014/06/22/gitlab-7-dot-0-released/)

closes https://github.com/progit/progit2-ja/issues/18
