### PR TITLE
Fix markup for index item "http-backend"

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -2,7 +2,7 @@
 
 (((serving repositories, HTTP)))
 We now have authenticated access though SSH and unauthenticated access through `git://`, but there is also a protocol that can do both at the same time.
-Setting up Smart HTTP is basically just enabling a CGI script that is provided with Git called `git-http-backend` on the server.((git commands, "http-backend"))
+Setting up Smart HTTP is basically just enabling a CGI script that is provided with Git called `git-http-backend` on the server.(((git commands, "http-backend")))
 This CGI will read the path and headers sent by a `git fetch` or `git push` to an HTTP URL and determine if the client can communicate over HTTP (which is true for any client since version 1.6.6).
 If the CGI sees that the client is smart, it will communicate smartly with it, otherwise it will fall back to the dumb behavior (so it is backward compatible for reads with older clients).
 


### PR DESCRIPTION
I'm assuming that you wanted this term to be on the index in the way others are, as markup with two sets of parentheses is also a valid syntax for indexes according to AsciiDoc user guide http://www.methods.co.nz/asciidoc/userguide.html#_indexes
