### PR TITLE
Adjusted filename in git merge output

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -155,7 +155,7 @@ $ git checkout master
 Switched to branch 'master'
 $ git merge iss53
 Merge made by the 'recursive' strategy.
-README |    1 +
+index.html |    1 +
 1 file changed, 1 insertion(+)
 ----
 


### PR DESCRIPTION
The previous operations on iss53 were clearly on index.html, so the merge output should reflect that too for consistency. :)
