### PR TITLE
Fix typo in URL of the smart git-receive-pack

### DIFF
--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -205,7 +205,7 @@ The client then makes another request, this time a `POST`, with the data that `g
 
 [source]
 ----
-=> POST http://server/simplegit-progit.git/git-receive/pack
+=> POST http://server/simplegit-progit.git/git-receive-pack
 ----
 
 The `POST` request includes the `send-pack` output and the packfile as its payload.


### PR DESCRIPTION
Reference: https://git.kernel.org/cgit/git/git.git/tree/Documentation/technical/http-protocol.txt#n292
