### PR TITLE
update shell output to console lexer

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -58,7 +58,7 @@ The only problem is that the blinking rate is too fast, we think it's much nicer
 
 First, we click the 'Fork' button as mentioned earlier to get our own copy of the project. Our user name here is ``tonychacon'' so our copy of this project is at `https://github.com/tonychacon/blink` and that's where we can edit it. We will clone it locally, create a topic branch, make the code change and finally push that change back up to GitHub.
 
-[source,shell]
+[source,console]
 ----
 $ git clone https://github.com/tonychacon/blink <1>
 Cloning into 'blink'...
@@ -201,7 +201,7 @@ If you want to merge in the target branch to make your Pull Request mergeable, y
 
 For example, let's say that in the ``tonychacon'' example we were using before, the original author made a change that would create a conflict in the Pull Request. Let's go through those steps.
 
-[source,shell]
+[source,console]
 ----
 $ git remote add upstream https://github.com/schacon/blink <1>
 

--- a/book/06-github/sections/3-maintaining.asc
+++ b/book/06-github/sections/3-maintaining.asc
@@ -77,7 +77,7 @@ If you notice the line that says `git pull <url> patch-1`, this is a simple way 
 
 The other interesting URLs are the `.diff` and `.patch` URLs, which as you may guess, provide unified diff and patch versions of the Pull Request. You could technically merge in the Pull Request work with something like this:
 
-[source,shell]
+[source,console]
 ----
 $ curl http://github.com/tonychacon/fade/pull/1.patch | git am
 ----
@@ -112,7 +112,7 @@ To demonstrate this, we're going to use a low-level command (often referred to a
 
 If we run this command against the ``blink'' repository we were using earlier, we will get a list of all the branches and tags and other references in the repository.
 
-[source,shell]
+[source,console]
 ----
 $ git ls-remote https://github.com/schacon/blink
 10d539600d86723087810ec636870a504f4fee4d	HEAD
@@ -133,7 +133,7 @@ There are two references per Pull Request - the one that ends in `/head` points 
 
 Now, you could do something like fetching the reference directly.
 
-[source,shell]
+[source,console]
 ----
 $ git fetch origin refs/pull/958/head
 From https://github.com/libgit2/libgit2
@@ -170,7 +170,7 @@ You can modify this section to add another refspec:
 That last line tells Git, ``All the refs that look like `refs/pull/123/head` should be stored locally like `refs/remotes/origin/pr/123`.''
 Now, if you save that file, and do a `git fetch`:
 
-[source,shell]
+[source,console]
 ----
 $ git fetch
 # …
@@ -183,7 +183,7 @@ $ git fetch
 Now all of the remote pull requests are represented locally with refs that act much like tracking branches; they're read-only, and they update when you do a fetch.
 This makes it super easy to try the code from a pull request locally:
 
-[source,shell]
+[source,console]
 ----
 $ git checkout pr/2
 Checking out files: 100% (3769/3769), done.

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -25,7 +25,7 @@ Once this step is done, Maven will automatically acquire and use the JGit librar
 If you would rather manage the binary dependencies yourself, pre-built JGit binaries are available from http://www.eclipse.org/jgit/download[].
 You can build them into your project by running a command like this:
 
-[source,shell]
+[source,console]
 ----
 javac -cp .:org.eclipse.jgit-3.5.0.201409260305-r.jar App.java
 java -cp .:org.eclipse.jgit-3.5.0.201409260305-r.jar App


### PR DESCRIPTION
This is a follow-up to 3275991. All shell output that were not updated
with that commit get updated with this pull request.

Please close this if those `[source,shell]` were unchanged on purpose.

closes https://github.com/progit/progit2-ja/issues/38
