### PR TITLE
fix explanation of git diff output

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -288,7 +288,7 @@ index 8ebb991..643e24f 100644
  that highlights your work in progress (and note in the PR title that it's
 ----
 
-That command compares what is in your working directory with what is in your staging area.
+That command compares what is in your working directory with what is in your last commit.
 The result tells you the changes you've made that you haven't yet staged.
 
 If you want to see what you've staged that will go into your next commit, you can use `git diff --staged`.


### PR DESCRIPTION
While it's true that git diff shows you the changes that you have not staged yet, the command compares the content of the working directory with the content of the last commit, not of the staging area.
