### PR TITLE
Change message to use imperative present tense

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -112,8 +112,8 @@ Initialized empty Git repository in /home/john/simplegit/.git/
 ...
 $ cd simplegit/
 $ vim lib/simplegit.rb
-$ git commit -am 'removed invalid default value'
-[master 738ee87] removed invalid default value
+$ git commit -am 'remove invalid default value'
+[master 738ee87] remove invalid default value
  1 files changed, 1 insertions(+), 1 deletions(-)
 -----
 
@@ -236,7 +236,7 @@ commit 738ee872852dfaa9d6634e0dea7a324040193016
 Author: John Smith <jsmith@example.com>
 Date:   Fri May 29 16:01:27 2009 -0700
 
-   removed invalid default value
+   remove invalid default value
 -----
 
 The `issue54..origin/master` syntax is a log filter that asks Git to only show the list of commits that are on the latter branch (in this case `origin/master`) that are not on the first branch (in this case `issue54`). We'll go over this syntax in detail in <<_commit_ranges>>.


### PR DESCRIPTION
Directly above this example commit message it's stated that one should use the imperative present tense, so I think it's best to show that right away in the following example.