### PR TITLE
Fix tiny article typo

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -31,7 +31,7 @@ After a few seconds, you'll be taken to your new project page, with your own wri
 
 (((GitHub, Flow)))
 GitHub is designed around a particular collaboration workflow, centered on Pull Requests.
-This flow works whether you're collaborating with a tightly-knit team in a single shared repository, or a globally-distributed company or network of strangers contributing to an project through dozens of forks.
+This flow works whether you're collaborating with a tightly-knit team in a single shared repository, or a globally-distributed company or network of strangers contributing to a project through dozens of forks.
 It is centered on the <<_topic_branch>> workflow covered  in <<_git_branching>>.
 
 Here's how it generally works:


### PR DESCRIPTION
Changed "an project" to "a project".