### PR TITLE
Replace dash with two hyphens for author date

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -171,7 +171,7 @@ a11bef0 - Scott Chacon, 6 years ago : first commit
 | `%p`     | Abbreviated parent hashes
 | `%an`    | Author name
 | `%ae`    | Author e-mail
-| `%ad`    | Author date (format respects the –date= option)
+| `%ad`    | Author date (format respects the --date=option)
 | `%ar`    | Author date, relative
 | `%cn`    | Committer name
 | `%ce`    | Committer email


### PR DESCRIPTION
As noted in #237 this fixes the typo for --date option.