### PR TITLE
Fix order of `git rm` options

### DIFF
--- a/book/10-git-internals/sections/maintenance.asc
+++ b/book/10-git-internals/sections/maintenance.asc
@@ -288,7 +288,7 @@ To do so, you use `filter-branch`, which you used in <<_rewriting_history>>:
 [source,console]
 ----
 $ git filter-branch --index-filter \
-  'git rm --cached --ignore-unmatch git.tgz' -- 7b30847^..
+  'git rm --ignore-unmatch --cached git.tgz' -- 7b30847^..
 Rewrite 7b30847d080183a1ab7d18fb202473b3096e9f34 (1/2)rm 'git.tgz'
 Rewrite dadf7258d699da2c8d89b09ef6670edb7d5f91b4 (2/2)
 Ref 'refs/heads/master' was rewritten


### PR DESCRIPTION
The `filter-branch` example errors out ('Unknown option ignore-unmatch') if the `--ignore-unmatch` flag does not come before the `--cached` flag.