### PR TITLE
git merge use: --squash doesn't need --no-commit

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -600,15 +600,15 @@ You start a new branch based off the current `origin/master` branch, squash the 
 [source,console]
 -----
 $ git checkout -b featureBv2 origin/master
-$ git merge --no-commit --squash featureB
+$ git merge --squash featureB
 # (change implementation)
 $ git commit
 $ git push myfork featureBv2
 -----
 
-The `--squash` option takes all the work on the merged branch and squashes it into one non-merge commit on top of the branch you're on.
-The `--no-commit` option tells Git not to automatically record a commit.
-This allows you to introduce all the changes from another branch and then make more changes before recording the new commit.
+The `--squash` option takes all the work on the merged branch and squashes it into one changeset producing the repository state as if a real merge happened, without actually making a merge commit.
+This means your future commit will have one parent only and allows you to introduce all the changes from another branch and then make more changes before recording the new commit.
+Also the `--no-commit` option can be useful to delay the merge commit in case of the default merge process.
 
 Now you can send the maintainer a message that you've made the requested changes and they can find those changes in your `featureBv2` branch.
 

--- a/book/07-git-tools/sections/subtree-merges.asc
+++ b/book/07-git-tools/sections/subtree-merges.asc
@@ -66,12 +66,12 @@ $ git pull
 ----
 
 Then, we can merge those changes back into our `master` branch.
-To pull in the changes and prepopulate the commit message, use the `--squash` and `--no-commit` options, as well as the recursive merge strategy's `-Xsubtree` option. (The recursive strategy is the default here, but we include it for clarity.)
+To pull in the changes and prepopulate the commit message, use the `--squash` option, as well as the recursive merge strategy's `-Xsubtree` option. (The recursive strategy is the default here, but we include it for clarity.)
 
 [source,console]
 ----
 $ git checkout master
-$ git merge --squash -s recursive -Xsubtree=rack --no-commit rack_branch
+$ git merge --squash -s recursive -Xsubtree=rack rack_branch
 Squash commit -- not updating HEAD
 Automatic merge went well; stopped before committing as requested
 ----


### PR DESCRIPTION
The use of the --no-commit option together with the --squash option
is redundant since according to the manual git merge --squash doesn't
automatically make commit after merging.