### PR TITLE
Advanced merging: use -Xignore-space-change

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -40,7 +40,7 @@ $ git commit -am 'converted hello.rb to DOS'
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 $ vim hello.rb
-$ git diff -w
+$ git diff -b
 diff --git a/hello.rb b/hello.rb
 index ac51efd..e85207e 100755
 --- a/hello.rb
@@ -121,11 +121,11 @@ If for some reason you find yourself in a horrible state and just want to start 
 
 In this specific case, the conflicts are whitespace related. We know this because the case is simple, but it's also pretty easy to tell in real cases when looking at the conflict because every line is removed on one side and added again on the other. By default, Git sees all of these lines as being changed, so it can't merge the files.
 
-The default merge strategy can take arguments though, and a few of them are about properly ignoring whitespace changes. If you see that you have a lot of whitespace issues in a merge, you can simply abort it and do it again, this time with `-Xignore-all-space` or `-Xignore-space-change`. The first option ignores changes in any **amount** of existing whitespace, the second ignores all whitespace changes altogether.
+The default merge strategy can take arguments though, and a few of them are about properly ignoring whitespace changes. If you see that you have a lot of whitespace issues in a merge, you can simply abort it and do it again, this time with `-Xignore-all-space` or `-Xignore-space-change`. The first option ignores whitespace **completely** when comparing lines, the second treats sequences of one or more whitespace characters as equivalent.
 
 [source,console]
 ----
-$ git merge -Xignore-all-space whitespace
+$ git merge -Xignore-space-change whitespace
 Auto-merging hello.rb
 Merge made by the 'recursive' strategy.
  hello.rb | 2 +-
@@ -178,7 +178,7 @@ dos2unix: converting file hello.theirs.rb to Unix format ...
 $ git merge-file -p \
     hello.ours.rb hello.common.rb hello.theirs.rb > hello.rb
 
-$ git diff -w
+$ git diff -b
 diff --cc hello.rb
 index 36c06c8,e85207e..0000000
 --- a/hello.rb
@@ -195,7 +195,7 @@ index 36c06c8,e85207e..0000000
   hello()
 ----
 
-At this point we have nicely merged the file. In fact, this actually works better than the `ignore-all-space` option because this actually fixes the whitespace changes before merge instead of simply ignoring them. In the `ignore-all-space` merge, we actually ended up with a few lines with DOS line endings, making things mixed.
+At this point we have nicely merged the file. In fact, this actually works better than the `ignore-space-change` option because this actually fixes the whitespace changes before merge instead of simply ignoring them. In the `ignore-space-change` merge, we actually ended up with a few lines with DOS line endings, making things mixed.
 
 If you want to get an idea before finalizing this commit about what was actually changed between one side or the other, you can ask `git diff` to compare what is in your working directory that you're about to commit as the result of the merge to any of these stages. Let's go through them all.
 
@@ -222,11 +222,11 @@ index 36c06c8..44d0a25 100755
 
 So here we can easily see that what happened in our branch, what we're actually introducing to this file with this merge, is changing that single line.
 
-If we want to see how the result of the merge differed from what was on their side, you can run `git diff --theirs`. In this and the following example, we have to use `-w` to strip out the whitespace because we're comparing it to what is in Git, not our cleaned up `hello.theirs.rb` file.
+If we want to see how the result of the merge differed from what was on their side, you can run `git diff --theirs`. In this and the following example, we have to use `-b` to strip out the whitespace because we're comparing it to what is in Git, not our cleaned up `hello.theirs.rb` file.
 
 [source,console]
 ----
-$ git diff --theirs -w
+$ git diff --theirs -b
 * Unmerged path hello.rb
 diff --git a/hello.rb b/hello.rb
 index e85207e..44d0a25 100755
@@ -245,7 +245,7 @@ Finally, you can see how the file has changed from both sides with `git diff --b
 
 [source,console]
 ----
-$ git diff --base -w
+$ git diff --base -b
 * Unmerged path hello.rb
 diff --git a/hello.rb b/hello.rb
 index ac51efd..44d0a25 100755

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -102,7 +102,7 @@ We use it to look for possible whitespace issues before committing with the `--c
 
 We see how to check the differences between branches more effectively with the `git diff A...B` syntax in <<_what_is_introduced>>.
 
-We use it to filter out whitespace differences with `-w` and how to compare different stages of conflicted files with `--theirs`, `--ours` and `--base` in <<_advanced_merging>>.
+We use it to filter out whitespace differences with `-b` and how to compare different stages of conflicted files with `--theirs`, `--ours` and `--base` in <<_advanced_merging>>.
 
 Finally, we use it to effectively compare submodule changes with `--submodule` in <<_starting_submodules>>.
 
@@ -192,7 +192,7 @@ The `git merge` command was first introduced in <<_basic_branching>>. Though it 
 
 We covered how to do a squashed merge (where Git merges the work but pretends like it's just a new commit without recording the history of the branch you're merging in) at the very end of <<_public_project>>.
 
-We went over a lot about the merge process and command, including the `-Xignore-all-whitespace` command and the `--abort` flag to abort a problem merge in <<_advanced_merging>>.
+We went over a lot about the merge process and command, including the `-Xignore-space-change` command and the `--abort` flag to abort a problem merge in <<_advanced_merging>>.
 
 We learned how to verify signatures before merging if your project is using GPG signing in <<_signing_commits>>.
 


### PR DESCRIPTION
The explanation for -Xignore-space-change and -Xignore-all-space options
was a bit reformulated.
And for most programming languages use of the -Xignore-space-change
option while merging could be more suitable than that of
the -Xignore-all-space option because it prevents different
lexemes from concatenating together (e.g. "def hello" and "defhello").