### PR TITLE
Renamed centralized.png

### DIFF
--- a/book/05-distributed-git/sections/distributed-workflows.asc
+++ b/book/05-distributed-git/sections/distributed-workflows.asc
@@ -15,7 +15,7 @@ One central hub, or repository, can accept code, and everyone synchronizes their
 A number of developers are nodes – consumers of that hub – and synchronize to that one place.
 
 .Centralized workflow.
-image::images/centralized_workflow.png[Centralized workflow.]
+image::images/centralized.png[Centralized workflow.]
 
 This means that if two developers clone from the hub and both make changes, the first developer to push their changes back up can do so with no problems.
 The second developer must merge in the first one's work before pushing changes up, so as not to overwrite the first developer's changes.


### PR DESCRIPTION
Renamed images/centralized_workflow.png to images/centralized.png to fix file reference.