### PR TITLE
Mention shortest command to track remote branches

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -138,6 +138,15 @@ Branch serverfix set up to track remote branch serverfix from origin.
 Switched to a new branch 'serverfix'
 ----
 
+In fact, this is so common that there's even a shortcut for that shortcut. If the branch name you're trying to checkout (a) doesn't exist and (b) exactly matches a name on only one remote, Git will create a tracking branch for you:
+
+[source,console]
+----
+$ git checkout serverfix
+Branch serverfix set up to track remote branch serverfix from origin.
+Switched to a new branch 'serverfix'
+----
+
 To set up a local branch with a different name than the remote branch, you can easily use the first version with a different local branch name:
 
 [source,console]


### PR DESCRIPTION
When reading the paragraph about tracking remote branches, I found it weird that the simple `git checkout <branch>` command was not mentioned. For a quick refresh, here is what the man page says:
```
git checkout <branch>
    [...]
    If <branch> is not found but there does exist a tracking branch in exactly one remote
    (call it <remote>) with a matching name, treat as equivalent to
        $ git checkout -b <branch> --track <remote>/<branch>
```
I've almost never explicitly tracked a branch, I always use this syntax if I have 1 remote because it's short and obvious.
I'm open to suggestions/rewordings/criticism.
               
