### PR TITLE
Branches in a Nutshell: Use unambiguous checksums

### DIFF
--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -1,4 +1,4 @@
-[[_git_branches_overview]]
+﻿[[_git_branches_overview]]
 === Branches in a Nutshell
 
 To really understand the way Git does branching, we need to take a step back and examine how Git stores its data.
@@ -9,7 +9,7 @@ When you make a commit, Git stores a commit object that contains a pointer to th
 This object also contains the author's name and email, the message that you typed, and pointers to the commit or commits that directly came before this commit (its parent or parents): zero parents for the initial commit, one parent for a normal commit, and multiple parents for a commit that results from a merge of two or more branches.
 
 To visualize this, let's assume that you have a directory containing three files, and you stage them all and commit.
-Staging the files checksums each one (the SHA-1 hash we mentioned in <<_getting_started>>), stores that version of the file in the Git repository (Git refers to them as blobs), and adds that checksum to the staging area:
+Staging the files computes a checksum for each one (the SHA-1 hash we mentioned in <<_getting_started>>), stores that version of the file in the Git repository (Git refers to them as blobs), and adds that checksum to the staging area:
 
 [source,console]
 ----


### PR DESCRIPTION
A first time reader sees "Staging the files checksums" and immediately wonders whether there's a typographic or grammatical error. While "checksum" sometimes occurs as a verb (see Wordnik, below), it is more often considered a noun (see Oxford and Webster, below).

A little editing removes the checksum ambiguity for more readers.

Oxford. http://www.oxforddictionaries.com/definition/english/checksum
Webster. http://www.merriam-webster.com/dictionary/checksum
Wordnik. https://www.wordnik.com/words/checksum
