### PR TITLE
sudo add sudo

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -15,11 +15,11 @@ This book was written using Git version *2.0.0*. Though most of the commands we 
 If you want to install Git on Linux via a binary installer, you can generally do so through the basic package-management tool that comes with your distribution.
 If you're on Fedora for example, you can use yum:
 
-  $ yum install git
+  $ sudo yum install git
 
 If you're on a Debian-based distribution like Ubuntu, try apt-get:
 
-  $ apt-get install git
+  $ sudo apt-get install git
 
 For more options, there are instructions for installing on several different Unix flavors on the Git website, at http://git-scm.com/download/linux[].
 
@@ -63,17 +63,17 @@ The binary installers tend to be a bit behind, though as Git has matured in rece
 If you do want to install Git from source, you need to have the following libraries that Git depends on: curl, zlib, openssl, expat, and libiconv.
 For example, if you're on a system that has yum (such as Fedora) or apt-get (such as a Debian based system), you can use one of these commands to install the minimal dependencies for compiling and installing the Git binaries:
 
-  $ yum install curl-devel expat-devel gettext-devel \
+  $ sudo yum install curl-devel expat-devel gettext-devel \
     openssl-devel zlib-devel
 
-  $ apt-get install libcurl4-gnutls-dev libexpat1-dev gettext \
+  $ sudo apt-get install libcurl4-gnutls-dev libexpat1-dev gettext \
     libz-dev libssl-dev
 
 In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required:
 
-  $ yum install asciidoc xmlto docbook2x
+  $ sudo yum install asciidoc xmlto docbook2x
 
-  $ apt-get install asciidoc xmlto docbook2x
+  $ sudo apt-get install asciidoc xmlto docbook2x
 
 When you have all the necessary dependencies, you can go ahead and grab the latest tagged release tarball from several places.
 You can get it via the Kernel.org site, at https://www.kernel.org/pub/software/scm/git[], or the mirror on the GitHub web site, at https://github.com/git/git/releases[].


### PR DESCRIPTION
Using the commands in the book, e.g
```
$ apt-get install git
```
Leaves an error message unfriendly to newbies and not evening mentioning sudo.
```bash
0 jan@osprey:~$apt-get install git
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
100 jan@osprey:~$
```
