### PR TITLE
Grammar fix: possessive for contraction

### DIFF
--- a/book/07-git-tools/sections/searching.asc
+++ b/book/07-git-tools/sections/searching.asc
@@ -1,7 +1,7 @@
 [[_searching]]
 === Searching
 
-With just about any size codebase, you'll often need to find where a function is called or defined, or find the history of a method. Git provides a couple of useful tools for looking through the code and commits stored in it's database quickly and easily. We'll go through a few of them.
+With just about any size codebase, you'll often need to find where a function is called or defined, or find the history of a method. Git provides a couple of useful tools for looking through the code and commits stored in its database quickly and easily. We'll go through a few of them.
 
 [[_git_grep]]
 ==== Git Grep


### PR DESCRIPTION
Just a minor typo spotted at the beginning of the Searching section of Chapter 7.