### PR TITLE
fixed error in the imap section

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -706,7 +706,32 @@ You can set each value separately with a series of `git config` commands, or you
 -----
 
 If your IMAP server doesn't use SSL, the last two lines probably aren't necessary, and the host value will be `imap://` instead of `imaps://`.
-When that is set up, you can use `git send-email` to place the patch series in the Drafts folder of the specified IMAP server:
+When that is set up, you can use `git imap-send` to place the patch series in the Drafts folder of the specified IMAP server:
+
+[source,console]
+-----
+$ cat *.patch |git imap-send
+Resolving imap.gmail.com... ok
+Connecting to [74.125.142.109]:993... ok
+Logging in...
+sending 2 messages
+100% (2/2) done
+-----
+
+At this point, you should be able to go to your Drafts folder, change the To field to the mailing list you're sending the patch to, possibly CC the maintainer or person responsible for that section, and send it off.
+
+You can also send the patches through an SMTP server. As before, you can set each value separately with a series of `git config` commands, or you can add them manually in the sendemail section in your `~/.gitconfig` file:
+
+[source,ini]
+-----
+[sendemail]
+  smtpencryption = tls
+  smtpserver = smtp.gmail.com
+  smtpuser = user@gmail.com
+  smtpserverport = 587
+-----
+
+After this is done, you can use `git send-email` to send your patches:
 
 [source,console]
 -----
@@ -738,8 +763,6 @@ References: <y>
 
 Result: OK
 -----
-
-At this point, you should be able to go to your Drafts folder, change the To field to the mailing list you're sending the patch to, possibly CC the maintainer or person responsible for that section, and send it off.
 
 ==== Summary
 

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -404,6 +404,12 @@ The `git format-patch` command is used to generate a series of patches in mbox f
 
 We go through an example of contributing to a project using the `git format-patch` tool in <<_project_over_email>>.
 
+==== git imap-send
+
+The `git imap-send` command uploads a mailbox generated with `git format-patch` into an IMAP drafts folder.
+
+We go through an example of contributing to a project by sending patches with the `git imap-send` tool in <<_project_over_email>>.
+
 ==== git send-email
 
 The `git send-email` command is used to send patches that are generated with `git format-patch` over email.


### PR DESCRIPTION
`git send-email` does not put the patches into an IMAP folder, but the
command `git imap-send`.
I've changed the command and added the output that occurs when using the
imap-send command. I also wrote a short sentence to make use of the previous
output used in the document, plus I added an example for an SMTP config.

Added `git imap-send` to the section email of git commands.