### PR TITLE
Example doesn't work on Windows 7.

### DIFF
--- a/book/02-git-basics/sections/aliases.asc
+++ b/book/02-git-basics/sections/aliases.asc
@@ -66,5 +66,5 @@ We can demonstrate by aliasing `git visual` to run `gitk`:
 
 [source,console]
 ----
-$ git config --global alias.visual "!gitk"
+$ git config --global alias.visual '!gitk'
 ----


### PR DESCRIPTION
Quotation marks doesn't work in the example on Git 1.9.5 on Windows 7. Only works with apostrophes.

Error:
Alexandre@MICROBOARD ~/projecs/ticgit (master)
$ git config --global alias.visual "!gitk"
sh.exe": !gitk: event not found

But:
Alexandre@MICROBOARD ~/projecs/ticgit (master)
$ git config --global alias.visual '!gitk'

Alexandre@MICROBOARD ~/projecs/ticgit (master)
$ git config alias.visual
!gitk