### PR TITLE
Several "remote branch" should be "remote-tracking branch".

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -4,11 +4,11 @@
 (((branches, remote)))(((references, remote)))
 Remote references are references (pointers) in your remote repositories, including branches, tags, and so on.
 You can get a full list of remote references explicitly with `git ls-remote (remote)`, or `git remote show (remote)` for remote branches as well as more information.
-Nevertheless, a more common way is to take the advantage of remote-tracking branches.
+Nevertheless, a more common way is to take advantage of remote-tracking branches.
 
 Remote-tracking branches are references to the state of remote branches.
 They're local references that you can't move; they're moved automatically for you whenever you do any network communication.
-Remote-tracking act as bookmarks to remind you where the branches in your remote repositories were the last time you connected to them.
+Remote-tracking branches act as bookmarks to remind you where the branches in your remote repositories were the last time you connected to them.
 
 They take the form `(remote)/(branch)`.
 For instance, if you wanted to see what the `master` branch on your `origin` remote looked like as of the last time you communicated with it, you would check the `origin/master` branch.

--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -2,9 +2,13 @@
 === Remote Branches
 
 (((branches, remote)))(((references, remote)))
-Remote branches are references (pointers) to the state of branches in your remote repositories.
-They're local branches that you can't move; they're moved automatically for you whenever you do any network communication.
-Remote branches act as bookmarks to remind you where the branches on your remote repositories were the last time you connected to them.
+Remote references are references (pointers) in your remote repositories, including branches, tags, and so on.
+You can get a full list of remote references explicitly with `git ls-remote (remote)`, or `git remote show (remote)` for remote branches as well as more information.
+Nevertheless, a more common way is to take the advantage of remote-tracking branches.
+
+Remote-tracking branches are references to the state of remote branches.
+They're local references that you can't move; they're moved automatically for you whenever you do any network communication.
+Remote-tracking act as bookmarks to remind you where the branches in your remote repositories were the last time you connected to them.
 
 They take the form `(remote)/(branch)`.
 For instance, if you wanted to see what the `master` branch on your `origin` remote looked like as of the last time you communicated with it, you would check the `origin/master` branch.
@@ -45,7 +49,7 @@ Name this remote `teamone`, which will be your shortname for that whole URL.
 image::images/remote-branches-4.png[Adding another server as a remote.]
 
 Now, you can run `git fetch teamone` to fetch everything the remote `teamone` server has that you don't have yet.
-Because that server has a subset of the data your `origin` server has right now, Git fetches no data but sets a remote branch called `teamone/master` to point to the commit that `teamone` has as its `master` branch.
+Because that server has a subset of the data your `origin` server has right now, Git fetches no data but sets a remote-tracking branch called `teamone/master` to point to the commit that `teamone` has as its `master` branch.
 
 .Remote tracking branch for `teamone/master`
 image::images/remote-branches-5.png[Remote tracking branch for `teamone/master`.]
@@ -103,11 +107,11 @@ From https://github.com/schacon/simplegit
  * [new branch]      serverfix    -> origin/serverfix
 ----
 
-It's important to note that when you do a fetch that brings down new remote branches, you don't automatically have local, editable copies of them.
+It's important to note that when you do a fetch that brings down new remote-tracking branches, you don't automatically have local, editable copies of them.
 In other words, in this case, you don't have a new `serverfix` branch – you only have an `origin/serverfix` pointer that you can't modify.
 
 To merge this work into your current working branch, you can run `git merge origin/serverfix`.
-If you want your own `serverfix` branch that you can work on, you can base it off your remote branch:
+If you want your own `serverfix` branch that you can work on, you can base it off your remote-tracking branch:
 
 [source,console]
 ----
@@ -122,7 +126,7 @@ This gives you a local branch that you can work on that starts where `origin/ser
 ==== Tracking Branches
 
 (((branches, tracking)))(((branches, upstream)))
-Checking out a local branch from a remote branch automatically creates what is called a ``tracking branch'' (or sometimes an ``upstream branch'').
+Checking out a local branch from a remote-tracking branch automatically creates what is called a ``tracking branch'' (or sometimes an ``upstream branch'').
 Tracking branches are local branches that have a direct relationship to a remote branch.
 If you're on a tracking branch and type `git pull`, Git automatically knows which server to fetch from and branch to merge into.
 


### PR DESCRIPTION
Also added some text to introduce remote references. Ref. #301.