### PR TITLE
git supports relative submodules URLs

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -21,7 +21,7 @@ This lets you clone another repository into your project and keep your commits s
 
 We'll walk through developing a simple project that has been split up into a main project and a few sub-projects.
 
-Let's start by adding an existing Git repository as a submodule of the repository that we're working on. To add a new submodule you use the `git submodule add` command with the URL of the project you would like to start tracking. In this example, we'll add a library called ``DbConnector''.
+Let's start by adding an existing Git repository as a submodule of the repository that we're working on. To add a new submodule you use the `git submodule add` command with the absolute or relative URL of the project you would like to start tracking. In this example, we'll add a library called ``DbConnector''.
 
 [source,console]
 ----
@@ -69,7 +69,7 @@ This is how other people who clone this project know where to get the submodule 
 
 [NOTE]
 =====
-Since the URL in the .gitmodules file is what other people will first try to clone/fetch from, make sure to use a URL that they can access if possible. For example, if you use a different URL to push to than others would to pull from, use the one that others have access to. You can overwrite this value locally with `git config submodule.DbConnector.url PRIVATE_URL` for your own use.
+Since the URL in the .gitmodules file is what other people will first try to clone/fetch from, make sure to use a URL that they can access if possible. For example, if you use a different URL to push to than others would to pull from, use the one that others have access to. You can overwrite this value locally with `git config submodule.DbConnector.url PRIVATE_URL` for your own use. When applicable, a relative URL can be helpful.
 =====
 
 The other listing in the `git status` output is the project folder entry.


### PR DESCRIPTION
Example: ../sibling.git

This is very helpful when server name changes depending on your location, or when repo is cloned using a fake hostname for any reason