### PR TITLE
file:// repos are often easier to damage by mistake

### DIFF
--- a/book/04-git-server/sections/protocols.asc
+++ b/book/04-git-server/sections/protocols.asc
@@ -56,9 +56,11 @@ If you and a co-worker are working on the same project and they want you to chec
 The cons of this method are that shared access is generally more difficult to set up and reach from multiple locations than basic network access.
 If you want to push from your laptop when you're at home, you have to mount the remote disk, which can be difficult and slow compared to network-based access.
 
-It's also important to mention that this isn't necessarily the fastest option if you're using a shared mount of some kind.
+It's important to mention that this isn't necessarily the fastest option if you're using a shared mount of some kind.
 A local repository is fast only if you have fast access to the data.
 A repository on NFS is often slower than the repository over SSH on the same server, allowing Git to run off local disks on each system.
+
+Finally, this protocol does not protect the repository against accidental damage. Every user has full shell access to the "remote" directory, and there is nothing preventing them from changing or removing internal Git files and corrupting the repository.
 
 ==== The HTTP Protocols
 


### PR DESCRIPTION
This commit is a proposal to insert as file:// cons the fact than damaging such repo is quite easy compared to other protocols.

Anyone can operate a rm -rf /* by mistake on its computer and delete mounted repository.