### PR TITLE
use of gender-neutral pronoun 'they'

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -174,7 +174,7 @@ image::images/perils-of-rebasing-4.png[You merge in the same work again into a n
 
 If you run a `git log` when your history looks like this, you'll see two commits that have the same author, date, and message, which will be confusing.
 Furthermore, if you push this history back up to the server, you'll reintroduce all those rebased commits to the central server, which can further confuse people.
-It's pretty safe to assume that the other developer doesn't want `C4` and `C6` to be in the history; that's why she rebased in the first place.
+It's pretty safe to assume that the other developer doesn't want `C4` and `C6` to be in the history; that's why they rebased in the first place.
 
 [[_rebase_rebase]]
 ==== Rebase When You Rebase


### PR DESCRIPTION
The gender-neutral pronoun 'they' is used many times in the text except in the following sentence :

`that's why she rebased in the first place.`