### PR TITLE
fix bad subject

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -153,7 +153,7 @@ Your commit history looks like this:
 image::images/perils-of-rebasing-1.png["Clone a repository, and base some work on it."]
 
 Now, someone else does more work that includes a merge, and pushes that work to the central server.
-You fetch them and merge the new remote branch into your work, making your history look something like this:
+You fetch it and merge the new remote branch into your work, making your history look something like this:
 
 .Fetch more commits, and merge them into your work
 image::images/perils-of-rebasing-2.png["Fetch more commits, and merge them into your work."]


### PR DESCRIPTION
`Now, someone else does more work that includes a merge, and pushes that work to the central server.`

In the previous sentence, we talk about the work done by another developer, not about their implicit commits.