### PR TITLE
Update basic-branching-and-merging.asc

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -146,7 +146,7 @@ If you need to pull it in, you can merge your `master` branch into your `iss53` 
 
 (((branches, merging)))(((merging)))
 Suppose you've decided that your issue #53 work is complete and ready to be merged into your `master` branch.
-In order to do that, you'll merge in your `iss53` branch, much like you merged in your `hotfix` branch earlier.
+In order to do that, you'll merge your `iss53` branch into `master`, much like you merged your `hotfix` branch earlier.
 All you have to do is check out the branch you wish to merge into and then run the `git merge` command:
 
 [source,console]


### PR DESCRIPTION
The wording "merge in iss53" was ambiguous and could be read with the opposite meaning: that you should be "in iss53" when you "merge". In other systems merging might actually be done in this opposite direction, so it was very confusing.