### PR TITLE
New line should separate sentences (02-git-basics/sections/recording-changes.asc)

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -106,7 +106,9 @@ Changes not staged for commit:
 ----
 
 The ``CONTRIBUTING.md'' file appears under a section named ``Changed but not staged for commit'' – which means that a file that is tracked has been modified in the working directory but not yet staged.
-To stage it, you run the `git add` command. `git add` is a multipurpose command – you use it to begin tracking new files, to stage files, and to do other things like marking merge-conflicted files as resolved. It may be helpful to think of it more as ``add this content to the next commit'' rather than ``add this file to the project''.(((git commands, add)))
+To stage it, you run the `git add` command.
+`git add` is a multipurpose command – you use it to begin tracking new files, to stage files, and to do other things like marking merge-conflicted files as resolved.
+It may be helpful to think of it more as ``add this content to the next commit'' rather than ``add this file to the project''.(((git commands, add)))
 Let's run `git add` now to stage the ``CONTRIBUTING.md'' file, and then run `git status` again:
 
 [source,console]
@@ -167,7 +169,9 @@ Changes to be committed:
 
 ==== Short Status
 
-While the `git status` output is pretty comprehensive, it's also quite wordy. Git also has a short status flag so you can see your changes in a more compact way. If you run `git status -s` or `git status --short` you get a far more simplified output from the command.
+While the `git status` output is pretty comprehensive, it's also quite wordy.
+Git also has a short status flag so you can see your changes in a more compact way.
+If you run `git status -s` or `git status --short` you get a far more simplified output from the command.
 
 [source,console]
 ----
@@ -179,7 +183,10 @@ M  lib/simplegit.rb
 ?? LICENSE.txt
 ----
 
-New files that aren't tracked have a `??` next to them, new files that have been added to the staging area have an `A`, modified files have an `M` and so on. There are two columns to the output - the left hand column indicates that the file is staged and the right hand column indicates that it's modified.  So for example in that output, the `README` file is modified in the working directory but not yet staged, while the `lib/simplegit.rb` file is modified and staged. The `Rakefile` was modified, staged and then modified again, so there are changes to it that are both staged and unstaged.
+New files that aren't tracked have a `??` next to them, new files that have been added to the staging area have an `A`, modified files have an `M` and so on.
+There are two columns to the output - the left hand column indicates that the file is staged and the right hand column indicates that it's modified.
+So for example in that output, the `README` file is modified in the working directory but not yet staged, while the `lib/simplegit.rb` file is modified and staged.
+The `Rakefile` was modified, staged and then modified again, so there are changes to it that are both staged and unstaged.
 
 [[_ignoring]]
 ==== Ignoring Files
@@ -310,7 +317,8 @@ index 0000000..03902a1
 It's important to note that `git diff` by itself doesn't show all changes made since your last commit – only changes that are still unstaged.
 This can be confusing, because if you've staged all of your changes, `git diff` will give you no output.
 
-For another example, if you stage the `CONTRIBUTING.md` file and then edit it, you can use `git diff` to see the changes in the file that are staged and the changes that are unstaged. If our environment looks like this:
+For another example, if you stage the `CONTRIBUTING.md` file and then edit it, you can use `git diff` to see the changes in the file that are staged and the changes that are unstaged.
+If our environment looks like this:
 
 [source,console]
 ----
@@ -370,7 +378,10 @@ index 8ebb991..643e24f 100644
 [NOTE]
 .Git Diff in an External Tool
 ====
-We will continue to use the `git diff` command in various ways throughout the rest of the book. There is another way to look at these diffs if you prefer a graphical or external diff viewing program instead. If you run `git difftool` instead of `git diff`, you can view any of these diffs in software like Araxis, emerge, vimdiff and more. Run `git difftool --tool-help` to see what is available on your system.
+We will continue to use the `git diff` command in various ways throughout the rest of the book.
+There is another way to look at these diffs if you prefer a graphical or external diff viewing program instead.
+If you run `git difftool` instead of `git diff`, you can view any of these diffs in software like Araxis, emerge, vimdiff and more.
+Run `git difftool --tool-help` to see what is available on your system.
 ====
 
 [[_committing_changes]]


### PR DESCRIPTION
There are few places in `book/02-git-basics/sections/recording-changes.asc` where rule mentioned in title of this PR is not fallowed. This PR fixes that, because "one sentence per line" is very helpful for translators :)