### PR TITLE
Bring text and example in line in undoing.asc

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -42,7 +42,7 @@ The `git status` command reminds you:
 
 [source,console]
 ----
-$ git add .
+$ git add *
 $ git status
 On branch master
 Changes to be committed:


### PR DESCRIPTION
Text uses "git add *", whereas the following example uses "git add .".

I chose "git add *" for both, but it looks like either is correct. See also http://stackoverflow.com/questions/26042390/git-add-asterisk-vs-git-add-period and http://stackoverflow.com/questions/16969768/what-does-git-add-git-add-single-dot-command-do.