### PR TITLE
Small confusing moments

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -239,8 +239,8 @@ build/
 # ignore doc/notes.txt, but not doc/server/arch.txt
 doc/*.txt
 
-# ignore all .txt files in the doc/ directory
-doc/**/*.txt
+# ignore all .pdf files in the doc/ directory
+doc/**/*.pdf
 ----
 
 [TIP]

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -323,7 +323,7 @@ If our environment looks like this:
 [source,console]
 ----
 $ git add CONTRIBUTING.md
-$ echo 'test line' >> CONTRIBUTING.md
+$ echo '# test line' >> CONTRIBUTING.md
 $ git status
 On branch master
 Changes to be committed:


### PR DESCRIPTION
1. We add 'test line' without a sharp sign and following git diff shows it with the sharp sign. It should be consistent.
2. Ignore rule doc/**/*.txt overrides doc/*.txt, so let's change to something clear.
