### PR TITLE
Fix Monospace Issue in 10-git-internals refspec

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -61,11 +61,11 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-In this case, the  master branch pull was rejected because it wasn't a fast-forward reference.
+In this case, the `master` branch pull was rejected because it wasn't a fast-forward reference.
 You can override that by specifying the `+` in front of the refspec.
 
 You can also specify multiple refspecs for fetching in your configuration file.
-If you want to always fetch the master and experiment branches, add two lines:
+If you want to always fetch the `master` and `experiment` branches, add two lines:
 
 [source,ini]
 ----
@@ -83,7 +83,7 @@ fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
 However, you can use namespaces (or directories) to accomplish something like that.
-If you have a QA team that pushes a series of branches, and you want to get the master branch and any of the QA team's branches but nothing else, you can use a config section like this:
+If you have a QA team that pushes a series of branches, and you want to get the `master` branch and any of the QA team's branches but nothing else, you can use a config section like this:
 
 [source,ini]
 ----
@@ -129,4 +129,4 @@ You can also use the refspec to delete references from the remote server by runn
 $ git push origin :topic
 ----
 
-Because the refspec is `<src>:<dst>`, by leaving off the `<src>` part, this basically says to make the topic branch on the remote nothing, which deletes it.
+Because the refspec is `<src>:<dst>`, by leaving off the `<src>` part, this basically says to make the `topic` branch on the remote nothing, which deletes it.


### PR DESCRIPTION
- All branch names is monospaced.
- Remove an extra whitespace.