### PR TITLE
Fix Monospace Issue in 07-git-tools advanced-merging

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -675,8 +675,8 @@ $
 You can see that there is no difference between the branch we were on and the result of the merge.
 
 This can often be useful to basically trick Git into thinking that a branch is already merged when doing a merge later on.
-For example, say you branched off a ``release'' branch and have done some work on it that you will want to merge back into your ``master'' branch at some point.
-In the meantime some bugfix on ``master'' needs to be backported into your `release` branch.
+For example, say you branched off a `release` branch and have done some work on it that you will want to merge back into your `master` branch at some point.
+In the meantime some bugfix on `master` needs to be backported into your `release` branch.
 You can merge the bugfix branch into the `release` branch and also `merge -s ours` the same branch into your `master` branch (even though the fix is already there) so when you later merge the `release` branch again, there are no conflicts from the bugfix.
 
 include::subtree-merges.asc[]


### PR DESCRIPTION
Update quoted branch names by monospaced names in this section.