### PR TITLE
fix a typo: .htaccess instead of .htpasswd

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -53,7 +53,7 @@ Finally you'll want to make writes be authenticated somehow, possibly with an Au
 </LocationMatch>
 ----
 
-That will require you to create a `.htaccess` file containing the passwords of all the valid users.
+That will require you to create a `.htpasswd` file containing the passwords of all the valid users.
 Here is an example of adding a ``schacon'' user to the file:
 
 [source,console]


### PR DESCRIPTION
It obviously should be .htpasswd not .htaccess here