### PR TITLE
Correct "git filter-branch" command line argument on PowerShell

### DIFF
--- a/book/09-git-and-other-scms/sections/import-tfs.asc
+++ b/book/09-git-and-other-scms/sections/import-tfs.asc
@@ -52,7 +52,7 @@ The following command will do that:
 
 [source,powershell]
 ----
-PS> git filter-branch -f --msg-filter 'sed "s/^git-tfs-id:.*$//g"' -- --all
+PS> git filter-branch -f --msg-filter 'sed "s/^git-tfs-id:.*$//g"' '--' --all
 ----
 
 That uses the `sed` command from the Git-bash environment to replace any line starting with ``git-tfs-id:'' with emptiness, which Git will then ignore.


### PR DESCRIPTION
With Git for Windows (https://msysgit.github.io/), folloing command

> PS C:\tmp\src\git\pullreq> git filter-branch -f --msg-filter 'sed "s/^git-tfs-id:.*$//g"' -- --all

gets following error message:

> usage: git core\git-filter-branch [--env-filter <command>] [--tree-filter <command>]
>  ...

Command line argument '--' should be quoted like:

> PS C:\tmp\src\git\pullreq> git filter-branch -f --msg-filter 'sed "s/^git-tfs-id:.*$//g"' '--' --all

and output message will be like this:

> Rewrite c9cea454ab929f2db984184647b9da9cc581abde (8/8)
> ...
