### PR TITLE
Replaced the usage of working directory with working tree in the basi…

### DIFF
--- a/book/01-introduction/sections/basics.asc
+++ b/book/01-introduction/sections/basics.asc
@@ -82,15 +82,15 @@ Committed means that the data is safely stored in your local database.
 Modified means that you have changed the file but have not committed it to your database yet.
 Staged means that you have marked a modified file in its current version to go into your next commit snapshot.
 
-This leads us to the three main sections of a Git project: the Git directory, the working directory, and the staging area.
+This leads us to the three main sections of a Git project: the Git directory, the working tree, and the staging area.
 
-.Working directory, staging area, and Git directory.
-image::images/areas.png["Working directory, staging area, and Git directory."]
+.Working tree, staging area, and Git directory.
+image::images/areas.png["Working tree, staging area, and Git directory."]
 
 The Git directory is where Git stores the metadata and object database for your project.
 This is the most important part of Git, and it is what is copied when you clone a repository from another computer.
 
-The working directory is a single checkout of one version of the project.
+The working tree is a single checkout of one version of the project.
 These files are pulled out of the compressed database in the Git directory and placed on disk for you to use or modify.
 
 The staging area is a file, generally contained in your Git directory, that stores information about what will go into your next commit.
@@ -98,7 +98,7 @@ It's sometimes referred to as the ``index'', but it's also common to refer to it
 
 The basic Git workflow goes something like this:
 
-1. You modify files in your working directory.
+1. You modify files in your working tree.
 2. You stage the files, adding snapshots of them to your staging area.
 3. You do a commit, which takes the files as they are in the staging area and stores that snapshot permanently to your Git directory.
 


### PR DESCRIPTION
According to the official Git documentation the term working tree should be used. If this PR gets merged, I'm happy to provide update to the other chapters

See http://git-scm.com/docs/git-read-tree