### PR TITLE
Use "Git for Windows" instead of "msysgit"

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -50,7 +50,7 @@ You can download that tool from the GitHub for Mac website, at http://mac.github
 There are also a few ways to install Git on Windows.(((Windows, installing)))
 The most official build is available for download on the Git website.
 Just go to http://git-scm.com/download/win[] and the download will start automatically.
-Note that this is a project called Git for Windows (also called msysGit), which is separate from Git itself; for more information on it, go to http://msysgit.github.io/[].
+Note that this is a project called Git for Windows, which is separate from Git itself; for more information on it, go to https://git-for-windows.github.io/[].
 
 Another easy way to get Git installed is by installing GitHub for Windows.
 The installer includes a command line version of Git as well as the GUI.

--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -19,7 +19,7 @@ config            id_dsa.pub
 
 You're looking for a pair of files named something like `id_dsa` or `id_rsa` and a matching file with a `.pub` extension.
 The `.pub` file is your public key, and the other file is your private key.
-If you don't have these files (or you don't even have a `.ssh` directory), you can create them by running a program called `ssh-keygen`, which is provided with the SSH package on Linux/Mac systems and comes with the MSysGit package on Windows:
+If you don't have these files (or you don't even have a `.ssh` directory), you can create them by running a program called `ssh-keygen`, which is provided with the SSH package on Linux/Mac systems and comes with Git for Windows:
 
 [source,console]
 ----


### PR DESCRIPTION
Git for Windows 2.5.0.**windows**.1 is released.
And the website is switched to https://git-for-windows.github.io/, see [GfW issue #12](https://github.com/git-for-windows/git/issues/12).

I think it's time to drop the "msysgit" totally in this book.

/cc @dscho