### PR TITLE
Further explain the real "/etc/gitconfig" file path when using Git for Windows 2.x

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -18,6 +18,7 @@ Each level overrides values in the previous level, so values in `.git/config` tr
 
 On Windows systems, Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).
 It also still looks for `/etc/gitconfig`, although it's relative to the MSys root, which is wherever you decide to install Git on your Windows system when you run the installer.
+However, if you are using Git for Windows 2.x, it is `C:\Doucuments and Settings\All Users\Application Data\Git\config` on Windows XP, and it is `C:\ProgramData\Git\config` on Windows Vista and newer.
 
 ==== Your Identity
 


### PR DESCRIPTION
Fixes #368.

/cc @dscho