### PR TITLE
Nearly every other [source,console] section was preceded by a colon

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -7,7 +7,7 @@ The second clones an existing Git repository from another server.
 
 ==== Initializing a Repository in an Existing Directory
 
-If you're starting to track an existing project in Git, you need to go to the project's directory and type
+If you're starting to track an existing project in Git, you need to go to the project's directory and type:
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -171,7 +171,7 @@ Changes to be committed:
 
 While the `git status` output is pretty comprehensive, it's also quite wordy.
 Git also has a short status flag so you can see your changes in a more compact way.
-If you run `git status -s` or `git status --short` you get a far more simplified output from the command.
+If you run `git status -s` or `git status --short` you get a far more simplified output from the command:
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -338,7 +338,7 @@ Changes not staged for commit:
     modified:   CONTRIBUTING.md
 ----
 
-Now you can use `git diff` to see what is still unstaged
+Now you can use `git diff` to see what is still unstaged:
 
 [source,console]
 ----
@@ -520,7 +520,7 @@ $ git rm --cached README
 ----
 
 You can pass files, directories, and file-glob patterns to the `git rm` command.
-That means you can do things such as
+That means you can do things such as:
 
 [source,console]
 ----
@@ -548,7 +548,7 @@ If you rename a file in Git, no metadata is stored in Git that tells it you rena
 However, Git is pretty smart about figuring that out after the fact – we'll deal with detecting file movement a bit later.
 
 Thus it's a bit confusing that Git has a `mv` command.
-If you want to rename a file in Git, you can run something like
+If you want to rename a file in Git, you can run something like:
 
 [source,console]
 ----


### PR DESCRIPTION
Trivial change: I noticed a few paragraphs describing [source,console] blocks that were not preceded by colon.