### PR TITLE
[core.editor] improve first time setup to include Notepad++

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -39,7 +39,8 @@ Many of the GUI tools will help you do this when you first run them.
 ==== Your Editor
 
 Now that your identity is set up, you can configure the default text editor that will be used when Git needs you to type in a message.
-If not configured, Git uses your system's default editor, which is generally Vim.
+If not configured, Git uses your system's default editor, which is system dependant.
+
 If you want to use a different text editor, such as Emacs, you can do the following:
 
 [source,console]
@@ -47,11 +48,29 @@ If you want to use a different text editor, such as Emacs, you can do the follow
 $ git config --global core.editor emacs
 ----
 
+While on a Windows system, if you want to use a different text editor, such as Notepad++, you can do the following:
+
+On a x86 system
+[source,console]
+----
+$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession" 
+----
+On a x64 system
+[source,console]
+----
+$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession" 
+----
+
+[NOTE]
+====
+Vim, Emacs and Notepad++ are popular text editors often used by developers on Unix based systems like Linux and OS X or a Windows system.
+If you are not familiar with either of these editors, you may need to search for specific instructions for how to set up your favorite editor with Git.
+====
+
 [WARNING]
 ====
-Vim and Emacs are popular text editors often used by developers on Unix based systems like Linux and Mac.
-If you are not familiar with either of these editors or are on a Windows system, you may need to search for instructions for how to set up your favorite editor with Git.
-If you don't set an editor like this and you don't know what Vim or Emacs are, you will likely get into a really confusing state when they are launched.
+You may find, if you don't setup an editor like this, you will likely get into a really confusing state when they are launched.
+Such example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
 ==== Checking Your Settings


### PR DESCRIPTION
On a Windows system, even though you have setup Notepad++ as default
system editor, Git seems to behave oddly during operations and you may trip over
glitches, like prematurely terminated Git operations before your edits
are complete.
Setting up core.editor in Git explicitly to Notepad++ fixes this behavior.

Related:

- [Preview of changes](https://github.com/uNiversaI/progit2/blob/a9f0bb3dca1cc28c13058012f2a6a47c10adbb47/book/01-introduction/sections/first-time-setup.asc)
- [Discussion issue #365](https://github.com/progit/progit2/issues/365)