### PR TITLE
Updated installing.asc to make [source,console] blocks consistent

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -18,12 +18,16 @@ If you want to install Git on Linux via a binary installer, you can generally do
 If you're on Fedora for example, you can use yum:
 
 [source,console]
-  $ sudo yum install git
+----
+$ sudo yum install git
+----
 
 If you're on a Debian-based distribution like Ubuntu, try apt-get:
 
 [source,console]
-  $ sudo apt-get install git
+----
+$ sudo apt-get install git
+----
 
 For more options, there are instructions for installing on several different Unix flavors on the Git website, at http://git-scm.com/download/linux[].
 
@@ -58,7 +62,6 @@ It also works well with Powershell, and sets up solid credential caching and san
 We'll learn more about those things a little later, but suffice it to say they're things you want.
 You can download this from the GitHub for Windows website, at http://windows.github.com[].
 
-
 ==== Installing from Source
 
 Some people may instead find it useful to install Git from source, because you'll get the most recent version.
@@ -68,16 +71,20 @@ If you do want to install Git from source, you need to have the following librar
 For example, if you're on a system that has yum (such as Fedora) or apt-get (such as a Debian based system), you can use one of these commands to install the minimal dependencies for compiling and installing the Git binaries:
 
 [source,console]
-  $ sudo yum install curl-devel expat-devel gettext-devel \
-    openssl-devel zlib-devel
-  $ sudo apt-get install libcurl4-gnutls-dev libexpat1-dev gettext \
-    libz-dev libssl-dev
+----
+$ sudo yum install curl-devel expat-devel gettext-devel \
+  openssl-devel zlib-devel
+$ sudo apt-get install libcurl4-gnutls-dev libexpat1-dev gettext \
+  libz-dev libssl-dev
+----
 
 In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required:
 
 [source,console]
-  $ sudo yum install asciidoc xmlto docbook2x
-  $ sudo apt-get install asciidoc xmlto docbook2x
+----
+$ sudo yum install asciidoc xmlto docbook2x
+$ sudo apt-get install asciidoc xmlto docbook2x
+----
 
 When you have all the necessary dependencies, you can go ahead and grab the latest tagged release tarball from several places.
 You can get it via the Kernel.org site, at https://www.kernel.org/pub/software/scm/git[], or the mirror on the GitHub web site, at https://github.com/git/git/releases[].
@@ -86,14 +93,18 @@ It's generally a little clearer what the latest version is on the GitHub page, b
 Then, compile and install:
 
 [source,console]
-  $ tar -zxf git-2.0.0.tar.gz
-  $ cd git-2.0.0
-  $ make configure
-  $ ./configure --prefix=/usr
-  $ make all doc info
-  $ sudo make install install-doc install-html install-info
+----
+$ tar -zxf git-2.0.0.tar.gz
+$ cd git-2.0.0
+$ make configure
+$ ./configure --prefix=/usr
+$ make all doc info
+$ sudo make install install-doc install-html install-info
+----
 
 After this is done, you can also get Git via Git itself for updates:
 
 [source,console]
-  $ git clone git://git.kernel.org/pub/scm/git/git.git
+----
+$ git clone git://git.kernel.org/pub/scm/git/git.git
+----


### PR DESCRIPTION
A number of [source,console] blocks in the 01-Introduction chapter weren't subject to syntax highlighting as they should have been. This PR makes the impacted blocks consistent with the rest of the section.