### PR TITLE
Add missing shell prompt to console block

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -9,7 +9,7 @@ To get the project, run
 
 [source,console]
 ----
-git clone https://github.com/schacon/simplegit-progit
+$ git clone https://github.com/schacon/simplegit-progit
 ----
 
 When you run `git log` in this project, you should get output that looks something like this:(((git commands, log)))


### PR DESCRIPTION
This was the only issue I found when reviewing the console blocks in Chapter 2.