### PR TITLE
Fix console blocks in 05-distributed-git

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -64,7 +64,7 @@ Instead of ``I added tests for'' or ``Adding tests for,'' use ``Add tests for.''
 Here is a template originally written by Tim Pope:
 
 [source,text]
------
+----
 Short (50 chars or less) summary of changes
 
 More detailed explanatory text, if necessary.  Wrap it to
@@ -82,7 +82,7 @@ Further paragraphs come after blank lines.
   - Typically a hyphen or asterisk is used for the bullet,
     preceded by a single space, with blank lines in
     between, but conventions vary here
------
+----
 
 If all your commit messages look like this, things will be a lot easier for you and the developers you work with.
 The Git project has well-formatted commit messages – try running `git log --no-merges` there to see what a nicely formatted project-commit history looks like.
@@ -105,7 +105,7 @@ The first developer, John, clones the repository, makes a change, and commits lo
 (The protocol messages have been replaced with `...` in these examples to shorten them somewhat.)
 
 [source,console]
------
+----
 # John's Machine
 $ git clone john@githost:simplegit.git
 Initialized empty Git repository in /home/john/simplegit/.git/
@@ -115,12 +115,12 @@ $ vim lib/simplegit.rb
 $ git commit -am 'removed invalid default value'
 [master 738ee87] removed invalid default value
  1 files changed, 1 insertions(+), 1 deletions(-)
------
+----
 
 The second developer, Jessica, does the same thing – clones the repository and commits a change:
 
 [source,console]
------
+----
 # Jessica's Machine
 $ git clone jessica@githost:simplegit.git
 Initialized empty Git repository in /home/jessica/simplegit/.git/
@@ -130,29 +130,29 @@ $ vim TODO
 $ git commit -am 'add reset task'
 [master fbff5bc] add reset task
  1 files changed, 1 insertions(+), 0 deletions(-)
------
+----
 
 Now, Jessica pushes her work up to the server:
 
 [source,console]
------
+----
 # Jessica's Machine
 $ git push origin master
 ...
 To jessica@githost:simplegit.git
    1edee6b..fbff5bc  master -> master
------
+----
 
 John tries to push his change up, too:
 
 [source,console]
------
+----
 # John's Machine
 $ git push origin master
 To john@githost:simplegit.git
  ! [rejected]        master -> master (non-fast forward)
 error: failed to push some refs to 'john@githost:simplegit.git'
------
+----
 
 John isn't allowed to push because Jessica has pushed in the meantime.
 This is especially important to understand if you're used to Subversion, because you'll notice that the two developers didn't edit the same file.
@@ -160,12 +160,12 @@ Although Subversion automatically does such a merge on the server if different f
 John has to fetch Jessica's changes and merge them in before he will be allowed to push:
 
 [source,console]
------
+----
 $ git fetch origin
 ...
 From john@githost:simplegit
  + 049d078...fbff5bc master     -> origin/master
------
+----
 
 At this point, John's local repository looks something like this:
 
@@ -175,12 +175,12 @@ image::images/small-team-1.png[John's divergent history.]
 John has a reference to the changes Jessica pushed up, but he has to merge them into his own work before he is allowed to push:
 
 [source,console]
------
+----
 $ git merge origin/master
 Merge made by recursive.
  TODO |    1 +
  1 files changed, 1 insertions(+), 0 deletions(-)
------
+----
 
 The merge goes smoothly – John's commit history now looks like this:
 
@@ -190,12 +190,12 @@ image::images/small-team-2.png[John's repository after merging `origin/master`.]
 Now, John can test his code to make sure it still works properly, and then he can push his new merged work up to the server:
 
 [source,console]
------
+----
 $ git push origin master
 ...
 To john@githost:simplegit.git
    fbff5bc..72bbc59  master -> master
------
+----
 
 Finally, John's commit history looks like this:
 
@@ -212,13 +212,13 @@ image::images/small-team-4.png[Jessica's topic branch.]
 Jessica wants to sync up with John, so she fetches:
 
 [source,console]
------
+----
 # Jessica's Machine
 $ git fetch origin
 ...
 From jessica@githost:simplegit
    fbff5bc..72bbc59  master     -> origin/master
------
+----
 
 That pulls down the work John has pushed up in the meantime.
 Jessica's history now looks like this:
@@ -230,14 +230,14 @@ Jessica thinks her topic branch is ready, but she wants to know what she has to 
 She runs `git log` to find out:
 
 [source,console]
------
+----
 $ git log --no-merges issue54..origin/master
 commit 738ee872852dfaa9d6634e0dea7a324040193016
 Author: John Smith <jsmith@example.com>
 Date:   Fri May 29 16:01:27 2009 -0700
 
    removed invalid default value
------
+----
 
 The `issue54..origin/master` syntax is a log filter that asks Git to only show the list of commits that are on the latter branch (in this case `origin/master`) that are not on the first branch (in this case `issue54`).
 We'll go over this syntax in detail in <<_commit_ranges>>.
@@ -249,37 +249,37 @@ Now, Jessica can merge her topic work into her master branch, merge John's work 
 First, she switches back to her master branch to integrate all this work:
 
 [source,console]
------
+----
 $ git checkout master
 Switched to branch 'master'
 Your branch is behind 'origin/master' by 2 commits, and can be fast-forwarded.
------
+----
 
 She can merge either `origin/master` or `issue54` first – they're both upstream, so the order doesn't matter.
 The end snapshot should be identical no matter which order she chooses; only the history will be slightly different.
 She chooses to merge in `issue54` first:
 
 [source,console]
------
+----
 $ git merge issue54
 Updating fbff5bc..4af4298
 Fast forward
  README           |    1 +
  lib/simplegit.rb |    6 +++++-
  2 files changed, 6 insertions(+), 1 deletions(-)
------
+----
 
 No problems occur; as you can see it was a simple fast-forward.
 Now Jessica merges in John's work (`origin/master`):
 
 [source,console]
------
+----
 $ git merge origin/master
 Auto-merging lib/simplegit.rb
 Merge made by recursive.
  lib/simplegit.rb |    2 +-
  1 files changed, 1 insertions(+), 1 deletions(-)
------
+----
 
 Everything merges cleanly, and Jessica's history looks like this:
 
@@ -289,12 +289,12 @@ image::images/small-team-6.png[Jessica's history after merging John's changes.]
 Now `origin/master` is reachable from Jessica's `master` branch, so she should be able to successfully push (assuming John hasn't pushed again in the meantime):
 
 [source,console]
------
+----
 $ git push origin master
 ...
 To jessica@githost:simplegit.git
    72bbc59..8059c15  master -> master
------
+----
 
 Each developer has committed a few times and merged each other's work successfully.
 
@@ -324,7 +324,7 @@ Assuming she already has her repository cloned, she decides to work on `featureA
 She creates a new branch for the feature and does some work on it there:
 
 [source,console]
------
+----
 # Jessica's Machine
 $ git checkout -b featureA
 Switched to a new branch 'featureA'
@@ -332,35 +332,35 @@ $ vim lib/simplegit.rb
 $ git commit -am 'add limit to log function'
 [featureA 3300904] add limit to log function
  1 files changed, 1 insertions(+), 1 deletions(-)
------
+----
 
 At this point, she needs to share her work with John, so she pushes her `featureA` branch commits up to the server.
 Jessica doesn't have push access to the `master` branch – only the integrators do – so she has to push to another branch in order to collaborate with John:
 
 [source,console]
------
+----
 $ git push -u origin featureA
 ...
 To jessica@githost:simplegit.git
  * [new branch]      featureA -> featureA
------
+----
 
 Jessica emails John to tell him that she's pushed some work into a branch named `featureA` and he can look at it now.
 While she waits for feedback from John, Jessica decides to start working on `featureB` with Josie.
 To begin, she starts a new feature branch, basing it off the server's `master` branch:
 
 [source,console]
------
+----
 # Jessica's Machine
 $ git fetch origin
 $ git checkout -b featureB origin/master
 Switched to a new branch 'featureB'
------
+----
 
 Now, Jessica makes a couple of commits on the `featureB` branch:
 
 [source,console]
------
+----
 $ vim lib/simplegit.rb
 $ git commit -am 'made the ls-tree function recursive'
 [featureB e5b0fdc] made the ls-tree function recursive
@@ -369,7 +369,7 @@ $ vim lib/simplegit.rb
 $ git commit -am 'add ls-files'
 [featureB 8512791] add ls-files
  1 files changed, 5 insertions(+), 0 deletions(-)
------
+----
 
 Jessica's repository looks like this:
 
@@ -381,34 +381,34 @@ Jessica first needs to merge those changes in with her own before she can push t
 She can then fetch Josie's changes down with `git fetch`:
 
 [source,console]
------
+----
 $ git fetch origin
 ...
 From jessica@githost:simplegit
  * [new branch]      featureBee -> origin/featureBee
------
+----
 
 Jessica can now merge this into the work she did with `git merge`:
 
 [source,console]
------
+----
 $ git merge origin/featureBee
 Auto-merging lib/simplegit.rb
 Merge made by recursive.
  lib/simplegit.rb |    4 ++++
  1 files changed, 4 insertions(+), 0 deletions(-)
------
+----
 
 There is a bit of a problem – she needs to push the merged work in her `featureB` branch to the `featureBee` branch on the server.
 She can do so by specifying the local branch followed by a colon (:) followed by the remote branch to the `git push` command:
 
 [source,console]
------
+----
 $ git push -u origin featureB:featureBee
 ...
 To jessica@githost:simplegit.git
    fba9af8..cd685d1  featureB -> featureBee
------
+----
 
 This is called a _refspec_.
 See <<_refspec>> for a more detailed discussion of Git refspecs and different things you can do with them.
@@ -418,29 +418,29 @@ Next, John emails Jessica to say he's pushed some changes to the `featureA` bran
 She runs a `git fetch` to pull down those changes:
 
 [source,console]
------
+----
 $ git fetch origin
 ...
 From jessica@githost:simplegit
    3300904..aad881d  featureA   -> origin/featureA
------
+----
 
 Then, she can see what has been changed with `git log`:
 
 [source,console]
------
+----
 $ git log featureA..origin/featureA
 commit aad881d154acdaeb2b6b18ea0e827ed8a6d671e6
 Author: John Smith <jsmith@example.com>
 Date:   Fri May 29 19:57:33 2009 -0700
 
     changed log output to 30 from 25
------
+----
 
 Finally, she merges John's work into her own `featureA` branch:
 
 [source,console]
------
+----
 $ git checkout featureA
 Switched to branch 'featureA'
 $ git merge origin/featureA
@@ -448,12 +448,12 @@ Updating 3300904..aad881d
 Fast forward
  lib/simplegit.rb |   10 +++++++++-
 1 files changed, 9 insertions(+), 1 deletions(-)
------
+----
 
 Jessica wants to tweak something, so she commits again and then pushes this back up to the server:
 
 [source,console]
------
+----
 $ git commit -am 'small tweak'
 [featureA 774b3ed] small tweak
  1 files changed, 1 insertions(+), 1 deletions(-)
@@ -461,7 +461,7 @@ $ git push
 ...
 To jessica@githost:simplegit.git
    3300904..774b3ed  featureA -> featureA
------
+----
 
 Jessica's commit history now looks something like this:
 
@@ -495,7 +495,7 @@ First, you'll probably want to clone the main repository, create a topic branch 
 The sequence looks basically like this:
 
 [source,console]
------
+----
 $ git clone (url)
 $ cd project
 $ git checkout -b featureA
@@ -503,7 +503,7 @@ $ git checkout -b featureA
 $ git commit
 # (work)
 $ git commit
------
+----
 
 [NOTE]
 ====
@@ -514,9 +514,9 @@ When your branch work is finished and you're ready to contribute it back to the 
 You then need to add in this new repository URL as a second remote, in this case named `myfork`:
 
 [source,console]
------
+----
 $ git remote add myfork (url)
------
+----
 
 Then you need to push your work up to it.
 It's easiest to push the topic branch you're working on up to your repository, rather than merging into your master branch and pushing that up.
@@ -524,9 +524,9 @@ The reason is that if the work isn't accepted or is cherry picked, you don't hav
 If the maintainers merge, rebase, or cherry-pick your work, you'll eventually get it back via pulling from their repository anyhow:
 
 [source,console]
------
+----
 $ git push -u myfork featureA
------
+----
 
 (((git commands, request-pull)))
 When your work has been pushed up to your fork, you need to notify the maintainer.
@@ -536,7 +536,7 @@ The `request-pull` command takes the base branch into which you want your topic 
 For instance, if Jessica wants to send John a pull request, and she's done two commits on the topic branch she just pushed up, she can run this:
 
 [source,console]
------
+----
 $ git request-pull origin/master myfork
 The following changes since commit 1edee6b1d61823a2de3b09c160d7080b8d1b3a40:
   John Smith (1):
@@ -552,7 +552,7 @@ Jessica Smith (2):
 
  lib/simplegit.rb |   10 +++++++++-
  1 files changed, 9 insertions(+), 1 deletions(-)
------
+----
 
 The output can be sent to the maintainer – it tells them where the work was branched from, summarizes the commits, and tells where to pull this work from.
 
@@ -561,14 +561,14 @@ Having work themes isolated into topic branches also makes it easier for you to 
 For example, if you want to submit a second topic of work to the project, don't continue working on the topic branch you just pushed up – start over from the main repository's `master` branch:
 
 [source,console]
------
+----
 $ git checkout -b featureB origin/master
 # (work)
 $ git commit
 $ git push myfork featureB
 # (email maintainer)
 $ git fetch origin
------
+----
 
 Now, each of your topics is contained within a silo – similar to a patch queue – that you can rewrite, rebase, and modify without the topics interfering or interdepending on each other, like so:
 
@@ -579,11 +579,11 @@ Let's say the project maintainer has pulled in a bunch of other patches and trie
 In this case, you can try to rebase that branch on top of `origin/master`, resolve the conflicts for the maintainer, and then resubmit your changes:
 
 [source,console]
------
+----
 $ git checkout featureA
 $ git rebase origin/master
 $ git push -f myfork featureA
------
+----
 
 This rewrites your history to now look like <<psp_b>>.
 
@@ -600,13 +600,13 @@ You start a new branch based off the current `origin/master` branch, squash the 
 
 (((git commands, merge, squash)))
 [source,console]
------
+----
 $ git checkout -b featureBv2 origin/master
 $ git merge --squash featureB
 # (change implementation)
 $ git commit
 $ git push myfork featureBv2
------
+----
 
 The `--squash` option takes all the work on the merged branch and squashes it into one changeset producing the repository state as if a real merge happened, without actually making a merge commit.
 This means your future commit will have one parent only and allows you to introduce all the changes from another branch and then make more changes before recording the new commit.
@@ -629,13 +629,13 @@ The difference is how you submit them to the project.
 Instead of forking the project and pushing to your own writable version, you generate email versions of each commit series and email them to the developer mailing list:
 
 [source,console]
------
+----
 $ git checkout -b topicA
 # (work)
 $ git commit
 # (work)
 $ git commit
------
+----
 
 (((git commands, format-patch)))
 Now you have two commits that you want to send to the mailing list.
@@ -643,18 +643,18 @@ You use `git format-patch` to generate the mbox-formatted files that you can ema
 The nice thing about this is that applying a patch from an email generated with `format-patch` preserves all the commit information properly.
 
 [source,console]
------
+----
 $ git format-patch -M origin/master
 0001-add-limit-to-log-function.patch
 0002-changed-log-output-to-30-from-25.patch
------
+----
 
 The `format-patch` command prints out the names of the patch files it creates.
 The `-M` switch tells Git to look for renames.
 The files end up looking like this:
 
 [source,console]
------
+----
 $ cat 0001-add-limit-to-log-function.patch
 From 330090432754092d704da8e76ca5c05c198e71a8 Mon Sep 17 00:00:00 2001
 From: Jessica Smith <jessica@example.com>
@@ -682,7 +682,7 @@ index 76f47bc..f9815f1 100644
    def ls_tree(treeish = 'master')
 --
 2.1.0
------
+----
 
 You can also edit these patch files to add more information for the email list that you don't want to show up in the commit message.
 If you add text between the `---` line and the beginning of the patch (the `diff --git` line), then developers can read it; but applying the patch excludes it.
@@ -697,7 +697,7 @@ First, you need to set up the imap section in your `~/.gitconfig` file.
 You can set each value separately with a series of `git config` commands, or you can add them manually, but in the end your config file should look something like this:
 
 [source,ini]
------
+----
 [imap]
   folder = "[Gmail]/Drafts"
   host = imaps://imap.gmail.com
@@ -705,20 +705,20 @@ You can set each value separately with a series of `git config` commands, or you
   pass = p4ssw0rd
   port = 993
   sslverify = false
------
+----
 
 If your IMAP server doesn't use SSL, the last two lines probably aren't necessary, and the host value will be `imap://` instead of `imaps://`.
 When that is set up, you can use `git imap-send` to place the patch series in the Drafts folder of the specified IMAP server:
 
 [source,console]
------
+----
 $ cat *.patch |git imap-send
 Resolving imap.gmail.com... ok
 Connecting to [74.125.142.109]:993... ok
 Logging in...
 sending 2 messages
 100% (2/2) done
------
+----
 
 At this point, you should be able to go to your Drafts folder, change the To field to the mailing list you're sending the patch to, possibly CC the maintainer or person responsible for that section, and send it off.
 
@@ -726,18 +726,18 @@ You can also send the patches through an SMTP server.
 As before, you can set each value separately with a series of `git config` commands, or you can add them manually in the sendemail section in your `~/.gitconfig` file:
 
 [source,ini]
------
+----
 [sendemail]
   smtpencryption = tls
   smtpserver = smtp.gmail.com
   smtpuser = user@gmail.com
   smtpserverport = 587
------
+----
 
 After this is done, you can use `git send-email` to send your patches:
 
 [source,console]
------
+----
 $ git send-email *.patch
 0001-added-limit-to-log-function.patch
 0002-changed-log-output-to-30-from-25.patch
@@ -745,12 +745,12 @@ Who should the emails appear to be from? [Jessica Smith <jessica@example.com>]
 Emails will be sent from: Jessica Smith <jessica@example.com>
 Who should the emails be sent to? jessica@example.com
 Message-ID to be used as In-Reply-To for the first email? y
------
+----
 
 Then, Git spits out a bunch of log information looking something like this for each patch you're sending:
 
 [source,text]
------
+----
 (mbox) Adding cc: Jessica Smith <jessica@example.com> from
   \line 'From: Jessica Smith <jessica@example.com>'
 OK. Log says:
@@ -765,7 +765,7 @@ In-Reply-To: <y>
 References: <y>
 
 Result: OK
------
+----
 
 ==== Summary
 

--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -15,16 +15,16 @@ The maintainer of the Git project tends to namespace these branches as well – 
 As you'll remember, you can create the branch based off your master branch like this:
 
 [source,console]
------
+----
 $ git branch sc/ruby_client master
------
+----
 
 Or, if you want to also switch to it immediately, you can use the `checkout -b` option:
 
 [source,console]
------
+----
 $ git checkout -b sc/ruby_client master
------
+----
 
 Now you're ready to add your contributed work into this topic branch and determine if you want to merge it into your longer-term branches.
 
@@ -42,9 +42,9 @@ If you received the patch from someone who generated it with the `git diff` or a
 Assuming you saved the patch at `/tmp/patch-ruby-client.patch`, you can apply the patch like this:
 
 [source,console]
------
+----
 $ git apply /tmp/patch-ruby-client.patch
------
+----
 
 This modifies the files in your working directory.
 It's almost identical to running a `patch -p1` command to apply the patch, although it's more paranoid and accepts fewer fuzzy matches than patch.
@@ -56,11 +56,11 @@ It won't create a commit for you – after running it, you must stage and commit
 You can also use git apply to see if a patch applies cleanly before you try actually applying it – you can run `git apply --check` with the patch:
 
 [source,console]
------
+----
 $ git apply --check 0001-seeing-if-this-helps-the-gem.patch
 error: patch failed: ticgit.gemspec:1
 error: ticgit.gemspec: patch does not apply
------
+----
 
 If there is no output, then the patch should apply cleanly.
 This command also exits with a non-zero status if the check fails, so you can use it in scripts if you want.
@@ -78,14 +78,14 @@ Technically, `git am` is built to read an mbox file, which is a simple, plain-te
 It looks something like this:
 
 [source,console]
------
+----
 From 330090432754092d704da8e76ca5c05c198e71a8 Mon Sep 17 00:00:00 2001
 From: Jessica Smith <jessica@example.com>
 Date: Sun, 6 Apr 2008 10:17:23 -0700
 Subject: [PATCH 1/2] add limit to log function
 
 Limit log functionality to the first 20
------
+----
 
 This is the beginning of the output of the format-patch command that you saw in the previous section.
 This is also a valid mbox email format.
@@ -95,16 +95,17 @@ If you run a mail client that can save several emails out in mbox format, you ca
 However, if someone uploaded a patch file generated via `format-patch` to a ticketing system or something similar, you can save the file locally and then pass that file saved on your disk to `git am` to apply it:
 
 [source,console]
------
+----
 $ git am 0001-limit-log-function.patch
 Applying: add limit to log function
------
+----
 
 You can see that it applied cleanly and automatically created the new commit for you.
 The author information is taken from the email's `From` and `Date` headers, and the message of the commit is taken from the `Subject` and body (before the patch) of the email.
 For example, if this patch was applied from the mbox example above, the commit generated would look something like this:
 
------
+[source,console]
+----
 $ git log --pretty=fuller -1
 commit 6c5e70b984a60b3cecd395edd5b48a7575bf58e0
 Author:     Jessica Smith <jessica@example.com>
@@ -115,7 +116,7 @@ CommitDate: Thu Apr 9 09:19:06 2009 -0700
    add limit to log function
 
    Limit log functionality to the first 20
------
+----
 
 The `Commit` information indicates the person who applied the patch and the time it was applied.
 The `Author` information is the individual who originally created the patch and when it was originally created.
@@ -125,7 +126,7 @@ Perhaps your main branch has diverged too far from the branch the patch was buil
 In that case, the `git am` process will fail and ask you what you want to do:
 
 [source,console]
------
+----
 $ git am 0001-seeing-if-this-helps-the-gem.patch
 Applying: seeing if this helps the gem
 error: patch failed: ticgit.gemspec:1
@@ -134,25 +135,25 @@ Patch failed at 0001.
 When you have resolved this problem run "git am --resolved".
 If you would prefer to skip this patch, instead run "git am --skip".
 To restore the original branch and stop patching run "git am --abort".
------
+----
 
 This command puts conflict markers in any files it has issues with, much like a conflicted merge or rebase operation.
 You solve this issue much the same way – edit the file to resolve the conflict, stage the new file, and then run `git am --resolved` to continue to the next patch:
 
 [source,console]
------
+----
 $ (fix the file)
 $ git add ticgit.gemspec
 $ git am --resolved
 Applying: seeing if this helps the gem
------
+----
 
 If you want Git to try a bit more intelligently to resolve the conflict, you can pass a `-3` option to it, which makes Git attempt a three-way merge.
 This option isn't on by default because it doesn't work if the commit the patch says it was based on isn't in your repository.
 If you do have that commit – if the patch was based on a public commit – then the `-3` option is generally much smarter about applying a conflicting patch:
 
 [source,console]
------
+----
 $ git am -3 0001-seeing-if-this-helps-the-gem.patch
 Applying: seeing if this helps the gem
 error: patch failed: ticgit.gemspec:1
@@ -160,7 +161,7 @@ error: ticgit.gemspec: patch does not apply
 Using index info to reconstruct a base tree...
 Falling back to patching base and 3-way merge...
 No changes -- Patch already applied.
------
+----
 
 In this case, this patch had already been applied.
 Without the `-3` option, it looks like a conflict.
@@ -168,14 +169,14 @@ Without the `-3` option, it looks like a conflict.
 If you're applying a number of patches from an mbox, you can also run the `am` command in interactive mode, which stops at each patch it finds and asks if you want to apply it:
 
 [source,console]
------
+----
 $ git am -3 -i mbox
 Commit Body is:
 --------------------------
 seeing if this helps the gem
 --------------------------
 Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all
------
+----
 
 This is nice if you have a number of patches saved, because you can view the patch first if you don't remember what it is, or not apply the patch if you've already done so.
 
@@ -190,11 +191,11 @@ If your contribution came from a Git user who set up their own repository, pushe
 For instance, if Jessica sends you an email saying that she has a great new feature in the `ruby-client` branch of her repository, you can test it by adding the remote and checking out that branch locally:
 
 [source,console]
------
+----
 $ git remote add jessica git://github.com/jessica/myproject.git
 $ git fetch jessica
 $ git checkout -b rubyclient jessica/ruby-client
------
+----
 
 If she emails you again later with another branch containing another great feature, you can fetch and check out because you already have the remote setup.
 
@@ -210,12 +211,12 @@ If you aren't working with a person consistently but still want to pull from the
 This does a one-time pull and doesn't save the URL as a remote reference:
 
 [source,console]
------
+----
 $ git pull https://github.com/onetimeguy/project
 From https://github.com/onetimeguy/project
  * branch            HEAD       -> FETCH_HEAD
 Merge made by recursive.
------
+----
 
 [[_what_is_introduced]]
 ==== Determining What Is Introduced
@@ -231,7 +232,7 @@ This does the same thing as the `master..contrib` format that we used earlier.
 For example, if your contributor sends you two patches and you create a branch called `contrib` and applied those patches there, you can run this:
 
 [source,console]
------
+----
 $ git log contrib --not master
 commit 5b6235bd297351589efc4d73316f0a68d484f118
 Author: Scott Chacon <schacon@gmail.com>
@@ -244,7 +245,7 @@ Author: Scott Chacon <schacon@gmail.com>
 Date:   Mon Oct 22 19:38:36 2008 -0700
 
     updated the gemspec to hopefully work better
------
+----
 
 To see what changes each commit introduces, remember that you can pass the `-p` option to `git log` and it will append the diff introduced to each commit.
 
@@ -252,9 +253,9 @@ To see a full diff of what would happen if you were to merge this topic branch w
 You may think to run this:
 
 [source,console]
------
+----
 $ git diff master
------
+----
 
 This command gives you a diff, but it may be misleading.
 If your `master` branch has moved forward since you created the topic branch from it, then you'll get seemingly strange results.
@@ -269,19 +270,19 @@ You do that by having Git compare the last commit on your topic branch with the 
 Technically, you can do that by explicitly figuring out the common ancestor and then running your diff on it:
 
 [source,console]
------
+----
 $ git merge-base contrib master
 36c7dba2c95e6bbb78dfa822519ecfec6e1ca649
 $ git diff 36c7db
------
+----
 
 However, that isn't convenient, so Git provides another shorthand for doing the same thing: the triple-dot syntax.
 In the context of the `diff` command, you can put three periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
 
 [source,console]
------
+----
 $ git diff master...contrib
------
+----
 
 This command shows you only the work your current topic branch has introduced since its common ancestor with master.
 That is a very useful syntax to remember.
@@ -376,12 +377,12 @@ image::images/rebasing-1.png[Example history before a cherry-pick.]
 If you want to pull commit `e43a6` into your master branch, you can run
 
 [source,console]
------
+----
 $ git cherry-pick e43a6fd3e94888d76779ad79fb568ed180e5fcdf
 Finished one cherry-pick.
 [master]: created a0a41a9: "More friendly message when locking the index fails."
  3 files changed, 17 insertions(+), 3 deletions(-)
------
+----
 
 This pulls the same change introduced in `e43a6`, but you get a new commit SHA-1 value, because the date applied is different.
 Now your history looks like this:
@@ -423,49 +424,49 @@ You can create a new tag as discussed in <<_git_basics_chapter>>.
 If you decide to sign the tag as the maintainer, the tagging may look something like this:
 
 [source,console]
------
+----
 $ git tag -s v1.5 -m 'my signed 1.5 tag'
 You need a passphrase to unlock the secret key for
 user: "Scott Chacon <schacon@gmail.com>"
 1024-bit DSA key, ID F721C45A, created 2009-02-09
------
+----
 
 If you do sign your tags, you may have the problem of distributing the public PGP key used to sign your tags.
 The maintainer of the Git project has solved this issue by including their public key as a blob in the repository and then adding a tag that points directly to that content.
 To do this, you can figure out which key you want by running `gpg --list-keys`:
 
 [source,console]
------
+----
 $ gpg --list-keys
 /Users/schacon/.gnupg/pubring.gpg
 ---------------------------------
 pub   1024D/F721C45A 2009-02-09 [expires: 2010-02-09]
 uid                  Scott Chacon <schacon@gmail.com>
 sub   2048g/45D02282 2009-02-09 [expires: 2010-02-09]
------
+----
 
 Then, you can directly import the key into the Git database by exporting it and piping that through `git hash-object`, which writes a new blob with those contents into Git and gives you back the SHA-1 of the blob:
 
 [source,console]
------
+----
 $ gpg -a --export F721C45A | git hash-object -w --stdin
 659ef797d181633c87ec71ac3f9ba29fe5775b92
------
+----
 
 Now that you have the contents of your key in Git, you can create a tag that points directly to it by specifying the new SHA-1 value that the `hash-object` command gave you:
 
 [source,console]
------
+----
 $ git tag -a maintainer-pgp-pub 659ef797d181633c87ec71ac3f9ba29fe5775b92
------
+----
 
 If you run `git push --tags`, the `maintainer-pgp-pub` tag will be shared with everyone.
 If anyone wants to verify a tag, they can directly import your PGP key by pulling the blob directly out of the database and importing it into GPG:
 
 [source,console]
------
+----
 $ git show maintainer-pgp-pub | gpg --import
------
+----
 
 They can use that key to verify all your signed tags.
 Also, if you include instructions in the tag message, running `git show <tag>` will let you give the end user more specific instructions about tag verification.
@@ -478,10 +479,10 @@ Because Git doesn't have monotonically increasing numbers like 'v123' or the equ
 Git gives you the name of the nearest tag with the number of commits on top of that tag and a partial SHA-1 value of the commit you're describing:
 
 [source,console]
------
+----
 $ git describe master
 v1.6.2-rc1-20-g8c5b85c
------
+----
 
 This way, you can export a snapshot or build and name it something understandable to people.
 In fact, if you build Git from source code cloned from the Git repository, `git --version` gives you something that looks like this.
@@ -500,19 +501,19 @@ One of the things you'll want to do is create an archive of the latest snapshot 
 The command to do this is `git archive`:
 
 [source,console]
------
+----
 $ git archive master --prefix='project/' | gzip > `git describe master`.tar.gz
 $ ls *.tar.gz
 v1.6.2-rc1-20-g8c5b85c.tar.gz
------
+----
 
 If someone opens that tarball, they get the latest snapshot of your project under a project directory.
 You can also create a zip archive in much the same way, but by passing the `--format=zip` option to `git archive`:
 
 [source,console]
------
+----
 $ git archive master --prefix='project/' --format=zip > `git describe master`.zip
------
+----
 
 You now have a nice tarball and a zip archive of your project release that you can upload to your website or email to people.
 
@@ -525,7 +526,7 @@ A nice way of quickly getting a sort of changelog of what has been added to your
 It summarizes all the commits in the range you give it; for example, the following gives you a summary of all the commits since your last release, if your last release was named v1.0.1:
 
 [source,console]
------
+----
 $ git shortlog --no-merges master --not v1.0.1
 Chris Wanstrath (8):
       Add support for annotated tags to Grit::Tag
@@ -540,6 +541,6 @@ Tom Preston-Werner (4):
       dynamic version method
       Version bump to 1.0.2
       Regenerated gemspec for version 1.0.2
------
+----
 
 You get a clean summary of all the commits since v1.0.1, grouped by author, that you can email to your list.


### PR DESCRIPTION
Fixed one source,console block in maintaining.asc that wasn't being highlighted and made all block start and end markers consistent with the rest of the book.