### PR TITLE
remove a colon before a link

### DIFF
--- a/book/06-github/sections/5-scripting.asc
+++ b/book/06-github/sections/5-scripting.asc
@@ -107,7 +107,7 @@ image::images/scripting-04-webhook-debug.png[Webhook debug]
 
 The other great feature of this is that you can redeliver any of the payloads to test your service easily.
 
-For more information on how to write webhooks and all the different event types you can listen for, go to the GitHub Developer documentation at: https://developer.github.com/webhooks/
+For more information on how to write webhooks and all the different event types you can listen for, go to the GitHub Developer documentation at https://developer.github.com/webhooks/
 
 ==== The GitHub API
 


### PR DESCRIPTION
The only place in the whole book where there was a colon before
the link (at: http:// --> at http://).