### PR TITLE
Fix example output of "git clone"

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -108,7 +108,7 @@ The first developer, John, clones the repository, makes a change, and commits lo
 ----
 # John's Machine
 $ git clone john@githost:simplegit.git
-Initialized empty Git repository in /home/john/simplegit/.git/
+Cloning into 'simplegit'...
 ...
 $ cd simplegit/
 $ vim lib/simplegit.rb
@@ -123,7 +123,7 @@ The second developer, Jessica, does the same thing – clones the repository and
 ----
 # Jessica's Machine
 $ git clone jessica@githost:simplegit.git
-Initialized empty Git repository in /home/jessica/simplegit/.git/
+Cloning into 'simplegit'...
 ...
 $ cd simplegit/
 $ vim TODO

--- a/book/07-git-tools/sections/bundling.asc
+++ b/book/07-git-tools/sections/bundling.asc
@@ -56,7 +56,8 @@ You can clone from the binary file into a directory, much like you would from a 
 [source,console]
 ----
 $ git clone repo.bundle repo
-Initialized empty Git repository in /private/tmp/bundle/repo/.git/
+Cloning into 'repo'...
+...
 $ cd repo
 $ git log --oneline
 9a466c5 second commit


### PR DESCRIPTION
"git clone" does not say "Initialized empty Git repository" (it may have
done so in very old versions), but "cloning into '$repo'". Reflect this
in the examples.

Noticed by Tim Castelijns:
http://stackoverflow.com/questions/32580578/why-the-git-commit-am-command-is-working-with-untraked-file-in-the-documenta