### PR TITLE
Updated installing.asc for Centos/Fedora

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -73,18 +73,27 @@ For example, if you're on a system that has yum (such as Fedora) or apt-get (suc
 [source,console]
 ----
 $ sudo yum install curl-devel expat-devel gettext-devel \
-  openssl-devel zlib-devel
+  openssl-devel perl-devel zlib-devel
 $ sudo apt-get install libcurl4-gnutls-dev libexpat1-dev gettext \
   libz-dev libssl-dev
 ----
 
-In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required:
+In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required (Note: users of RHEL and RHEL-derivatives like CentOS and Scientific Linux will have to https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F[enable the EPEL repository] to download the `docbook2X` package):
 
 [source,console]
 ----
-$ sudo yum install asciidoc xmlto docbook2x
+$ sudo yum install asciidoc xmlto docbook2X
 $ sudo apt-get install asciidoc xmlto docbook2x
 ----
+
+Additionally, if you're using Fedora/RHEL/RHEL-derivatives, you need to do this
+
+[source,console]
+----
+$ sudo ln -s /usr/bin/db2x_docbook2texi /usr/bin/docbook2x-texi
+----
+
+due to binary name differences.
 
 When you have all the necessary dependencies, you can go ahead and grab the latest tagged release tarball from several places.
 You can get it via the Kernel.org site, at https://www.kernel.org/pub/software/scm/git[], or the mirror on the GitHub web site, at https://github.com/git/git/releases[].


### PR DESCRIPTION
Compilation on Centos 6 requires perl-devel and docbook2X (uppercase X). I'm assuming this is the same for all other RHEL-likes.

docbook2X is only available through third-party repo like EPEL. Additionally, the binary is named `db2x_docbook2texi` instead of `docbook2x-texi` so symlinking is required.

Fixes #425.