### PR TITLE
Improve Smart HTTP section

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -18,6 +18,13 @@ $ a2enmod cgi alias env
 
 This also enables the `mod_cgi`, `mod_alias`, and `mod_env` modules, which are all needed for this to work properly.
 
+You’ll also need to set the Unix user group of the `/opt/git` directories to `www-data` so your web server can read- and write-access the repositories, because the Apache instance running the CGI script will (by default) be running as that user:
+
+[source,console]
+----
+$ chgrp -R www-data /opt/git
+----
+
 Next we need to add some things to the Apache configuration to run the `git-http-backend` as the handler for anything coming into the `/git` path of your web server.
 
 [source,console]

--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -13,10 +13,10 @@ If you don't have Apache setup, you can do so on a Linux box with something like
 [source,console]
 ----
 $ sudo apt-get install apache2 apache2-utils
-$ a2enmod cgi alias env
+$ a2enmod cgi alias env rewrite
 ----
 
-This also enables the `mod_cgi`, `mod_alias`, and `mod_env` modules, which are all needed for this to work properly.
+This also enables the `mod_cgi`, `mod_alias`, `mod_env`, and `mod_rewrite` modules, which are all needed for this to work properly.
 
 You’ll also need to set the Unix user group of the `/opt/git` directories to `www-data` so your web server can read- and write-access the repositories, because the Apache instance running the CGI script will (by default) be running as that user:
 
@@ -36,28 +36,24 @@ ScriptAlias /git/ /usr/lib/git-core/git-http-backend/
 
 If you leave out `GIT_HTTP_EXPORT_ALL` environment variable, then Git will only serve to unauthenticated clients the repositories with the `git-daemon-export-ok` file in them, just like the Git daemon did.
 
-Then you'll have to tell Apache to allow requests to that path with something like this:
+Finally you'll want to tell Apache to allow requests to `git-http-backend` and make writes be authenticated somehow, possibly with an Auth block like this:
 
 [source,console]
 ----
-<Directory "/usr/lib/git-core*">
-   Options ExecCGI Indexes
-   Order allow,deny
-   Allow from all
-   Require all granted
-</Directory>
-----
+RewriteEngine On
+RewriteCond %{QUERY_STRING} service=git-receive-pack [OR]
+RewriteCond %{REQUEST_URI} /git-receive-pack$
+RewriteRule ^/git/ - [E=AUTHREQUIRED]
 
-Finally you'll want to make writes be authenticated somehow, possibly with an Auth block like this:
-
-[source,console]
-----
-<LocationMatch "^/git/.*/git-receive-pack$">
+<Files "git-http-backend">
     AuthType Basic
     AuthName "Git Access"
     AuthUserFile /opt/git/.htpasswd
     Require valid-user
-</LocationMatch>
+    Order deny,allow
+    Deny from env=AUTHREQUIRED
+    Satisfy any
+</Files>
 ----
 
 That will require you to create a `.htpasswd` file containing the passwords of all the valid users.

--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -58,7 +58,7 @@ Here is an example of adding a ``schacon'' user to the file:
 
 [source,console]
 ----
-$ htdigest -c /opt/git/.htpasswd "Git Access" schacon
+$ htpasswd -c /opt/git/.htpasswd schacon
 ----
 
 There are tons of ways to have Apache authenticate users, you'll have to choose and implement one of them.


### PR DESCRIPTION
Issues arise during the very basic setup of Smart HTTP using the tutorial.

1. User files generated with htdigest and htpasswd are not compatible.
Thus, if AuthType Basic is used, htdigest must be changed to htpasswd.
The fix also resolves #122.

2. Apache process doesn’t have write permissions for the /opt/git/ subdirectories.
To address this, I suggest restoring the paragraph from this section:
https://git-scm.com/book/en/v1/Git-on-the-Server-Public-Access.
Namely, `$ chgrp -R www-data /opt/git`.

3. Authentication fails during push.
The initial ref advertisement request will fail without even giving an opportunity for authentication.
This is described in the git-http-backend man page examples: https://www.kernel.org/pub/software/scm/git/docs/git-http-backend.html
I have updated and simplified the authentication paragraph from the example to fit the context.
Also, the paragraph is merged with the git-core access authorization paragraph for brevity.