### PR TITLE
change 'winstore' credential option to 'wincred'

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,9 +19,8 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an ``osxkeychain'' mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, you can install a helper called ``winstore.''
+* If you're using Windows, you can install a helper called ``wincred.''
   This is similar to the ``osxkeychain'' helper described above, but uses the Windows Credential Store to control sensitive information.
-  It can be found at https://gitcredentialstore.codeplex.com[].
 
 You can choose one of these methods by setting a Git configuration value:
 
@@ -145,7 +144,7 @@ https://bob:s3cre7@mygithost
 ----
 
 It's just a series of lines, each of which contains a credential-decorated URL.
-The `osxkeychain` and `winstore` helpers use the native format of their backing stores, while `cache` uses its own in-memory format (which no other process can read).
+The `osxkeychain` and `wincred` helpers use the native format of their backing stores, while `cache` uses its own in-memory format (which no other process can read).
 
 ==== A Custom Credential Cache
 


### PR DESCRIPTION
I can't seem to find any information on using 'winstore' as a credential saving option on Windows. The link is outdated. 

With the default Git for Windows 2.6.1, when I run `git help -a` like the docs tell you to, it shows "crendential-wincred". 
https://git-scm.com/docs/gitcredentials

GitHub recommends to use "wincred" as well:
https://help.github.com/articles/caching-your-github-password-in-git/