### PR TITLE
zsh += vcs_info and native completion

### DIFF
--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -17,7 +17,7 @@ cherry-pick       -- apply changes introduced by some existing commits
 ----
 
 Ambiguous tab-completions aren't just listed; they have helpful descriptions, and you can graphically navigate the list by repeatedly hitting tab.
-This works with Git commands, their arguments, and names of things inside the repository (like refs and remotes), as well filenames and all the other things Zsh knows how to tab-complete.
+This works with Git commands, their arguments, and names of things inside the repository (like refs and remotes), as well as filenames and all the other things Zsh knows how to tab-complete.
 
 Zsh happens to be fairly compatible with Bash when it comes to prompt customization, but it allows you to have a right-side prompt as well.
 To include the branch name on the right side, add these lines to your `~/.zshrc` file:

--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -1,8 +1,8 @@
 === Git in Zsh
 
 (((zsh)))(((tab completion, zsh)))(((shell prompts, zsh)))
-Git also ships with a tab-completion library for Zsh.
-Just copy `contrib/completion/git-completion.zsh` to your home directory and source it from your `.zshrc`.
+Zsh also ships with a tab-completion library for Git.
+To use it, simply run `autoload -Uz compinit && compinit` in your `.zshrc`.
 Zsh's interface is a bit more powerful than Bash's:
 
 [source,console]
@@ -19,21 +19,33 @@ cherry-pick       -- apply changes introduced by some existing commits
 Ambiguous tab-completions aren't just listed; they have helpful descriptions, and you can graphically navigate the list by repeatedly hitting tab.
 This works with Git commands, their arguments, and names of things inside the repository (like refs and remotes), as well as filenames and all the other things Zsh knows how to tab-complete.
 
-Zsh happens to be fairly compatible with Bash when it comes to prompt customization, but it allows you to have a right-side prompt as well.
-To include the branch name on the right side, add these lines to your `~/.zshrc` file:
+Zsh ships with a framework for getting information from version control systems, called `vcs_info`.
+To include the branch name in the prompt on the right side, add these lines to your `~/.zshrc` file:
 
 [source,console]
 ----
+autoload -Uz vcs_info
+precmd_vcs_info() { vcs_info } 
+precmd_functions+=( precmd_vcs_info )
 setopt prompt_subst
-. ~/git-prompt.sh
-export RPROMPT=$'$(__git_ps1 "%s")'
+RPROMPT=\$vcs_info_msg_0_
+# PROMPT=\$vcs_info_msg_0_'%# '
+zstyle ':vcs_info:git:*' formats '%b'
 ----
 
 This results in a display of the current branch on the right-hand side of the terminal window, whenever your shell is inside a Git repository.
+(The left side is supported as well, of course; just uncomment the assignment to PROMPT.)
 It looks a bit like this:
 
 .Customized `zsh` prompt.
 image::images/zsh-prompt.png[Customized `zsh` prompt.]
+
+For more information on vcs_info, check out its documentation
+        in the `zshcontrib(1)` manual page,
+        or online at http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Version-Control-Information[].
+
+Instead of vcs_info, you might prefer the prompt customization script that ships with Git, called `git-prompt.sh`; see http://git-prompt.sh[] for details.
+`git-prompt.sh` is compatible with both Bash and Zsh.
 
 Zsh is powerful enough that there are entire frameworks dedicated to making it better.
 One of them is called "oh-my-zsh", and it can be found at https://github.com/robbyrussell/oh-my-zsh[].


### PR DESCRIPTION
Patch for [#422](https://github.com/progit/progit2/issues/422#issue-108144184)

(As discussed in #422, this patch is made available under the MIT license.)