### PR TITLE
upstart scripts go in /etc/init/

### DIFF
--- a/book/04-git-server/sections/git-daemon.asc
+++ b/book/04-git-server/sections/git-daemon.asc
@@ -25,7 +25,7 @@ So, in the following file
 
 [source,console]
 ----
-/etc/event.d/local-git-daemon
+/etc/init/local-git-daemon.conf
 ----
 
 you put this script:
@@ -37,6 +37,7 @@ stop on shutdown
 exec /usr/bin/git daemon \
     --user=git --group=git \
     --reuseaddr \
+    --detach \
     --base-path=/opt/git/ \
     /opt/git/
 respawn


### PR DESCRIPTION
Had some issues following this text when setting up my own git server. [Upstart scripts in ubuntu goes in /etc/init/](http://upstart.ubuntu.com/cookbook/#job-configuration-file). 
Also the daemon should run with the --detached option or else the upstart job will not run in a daemonised manner.