### PR TITLE
Use quotes - Single quotes not platform independent

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -26,7 +26,7 @@ If you're only interested in looking at the 1.8.5 series, you can run this:
 
 [source,console]
 ----
-$ git tag -l 'v1.8.5*'
+$ git tag -l "v1.8.5*"
 v1.8.5
 v1.8.5-rc0
 v1.8.5-rc1
@@ -58,7 +58,7 @@ The easiest way is to specify `-a` when you run the `tag` command:(((git command
 
 [source,console]
 ----
-$ git tag -a v1.4 -m 'my version 1.4'
+$ git tag -a v1.4 -m "my version 1.4"
 $ git tag
 v0.1
 v1.3


### PR DESCRIPTION
Using single quotes results in the error - fatal: Failed to resolve '[tag name]'' as a valid ref.