### PR TITLE
"pointer at" to "pointer to"

### DIFF
--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -59,7 +59,7 @@ You do this with the `git branch` command:(((git commands, branch)))
 $ git branch testing
 ----
 
-This creates a new pointer at the same commit you're currently on.
+This creates a new pointer to the same commit you're currently on.
 
 .Two branches pointing into the same series of commits
 image::images/two-branches.png[Two branches pointing into the same series of commits.]


### PR DESCRIPTION
The rest of Section 3.1 describes pointers as pointing 'to' something, and on this particular line it was 'creates a new pointer at', which might make the sentence seem a little incoherent on first glance.