### PR TITLE
fix a index for "C" in libgit2.asc

### DIFF
--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -1,6 +1,6 @@
 === Libgit2
 
-(((libgit2)))(((C)))
+(((libgit2)))((("C")))
 Another option at your disposal is to use Libgit2.
 Libgit2 is a dependency-free implementation of Git, with a focus on having a nice API for use within other programs.
 You can find it at http://libgit2.github.com[].


### PR DESCRIPTION
There is unnecessary copyright mark at the beggining of "A2.2 Embedding Git in your Applications - Libgit2".
https://git-scm.com/book/en/v2/Embedding-Git-in-your-Applications-Libgit2
This is because of (((C))) in libgit2.asc is treated as a copyright mark.
