### PR TITLE
Update Ch8 to refer to .gitattributes consistently

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -111,11 +111,18 @@ It's not perfect – formatting changes wouldn't show up here – but it certain
 
 Another interesting problem you can solve this way involves diffing image files.
 One way to do this is to run image files through a filter that extracts their EXIF information – metadata that is recorded with most image formats.
-If you download and install the `exiftool` program, you can use it to convert your images into text about the metadata, so at least the diff will show you a textual representation of any changes that happened:
+If you download and install the `exiftool` program, you can use it to convert your images into text about the metadata, so at least the diff will show you a textual representation of any changes that happened.
+Put the following line in your `.gitattributes` file:
+
+[source,ini]
+----
+*.png diff=exif
+----
+
+Configure Git to use this tool:
 
 [source,console]
 ----
-$ echo '*.png diff=exif' >> .gitattributes
 $ git config diff.exif.textconv exiftool
 ----
 
@@ -156,11 +163,18 @@ Git attributes offers you two ways to do this.
 
 First, you can inject the SHA-1 checksum of a blob into an `$Id$` field in the file automatically.
 If you set this attribute on a file or set of files, then the next time you check out that branch, Git will replace that field with the SHA-1 of the blob.
-It's important to notice that it isn't the SHA-1 of the commit, but of the blob itself:
+It's important to notice that it isn't the SHA-1 of the commit, but of the blob itself.
+Put the following line in your `.gitattributes` file:
+
+[source,ini]
+----
+*.txt ident
+----
+
+Add an `$Id$` reference to a test file:
 
 [source,console]
 ----
-$ echo '*.txt ident' >> .gitattributes
 $ echo '$Id$' > test.txt
 ----
 
@@ -234,12 +248,16 @@ $ git config filter.dater.clean 'perl -pe "s/\\\$Date[^\\\$]*\\\$/\\\$Date\\\$/"
 ----
 
 This Perl snippet strips out anything it sees in a `$Date$` string, to get back to where you started.
-Now that your filter is ready, you can test it by setting up a file with your `$Date$` keyword and then setting up a Git attribute for that file that engages the new filter:
+Now that your filter is ready, you can test it by setting up a Git attribute for that file that engages the new filter and creating a file with your `$Date$` keyword:
+
+[source,ini]
+----
+date*.txt filter=dater
+----
 
 [source,console]
 ----
 $ echo '# $Date$' > date_test.txt
-$ echo 'date*.txt filter=dater' >> .gitattributes
 ----
 
 If you commit those changes and check out the file again, you see the keyword properly substituted:
@@ -283,12 +301,16 @@ Now, when you run git archive to create a tarball of your project, that director
 When exporting files for deployment you can apply `git log`'s formatting and keyword-expansion processing to selected portions of files marked with the
 `export-subst` attribute.
 
-For instance, if you want to include a file named `LAST_COMMIT` in your project, and have metadata about the last commit automatically injected into it when `git archive` runs, you can for example set up the file like this:
+For instance, if you want to include a file named `LAST_COMMIT` in your project, and have metadata about the last commit automatically injected into it when `git archive` runs, you can for example set up your `.gitattributes` and `LAST_COMMIT` files like this:
+
+[source,ini]
+----
+LAST_COMMIT export-subst
+----
 
 [source,console]
 ----
 $ echo 'Last commit date: $Format:%cd by %aN$' > LAST_COMMIT
-$ echo "LAST_COMMIT export-subst" >> .gitattributes
 $ git add LAST_COMMIT .gitattributes
 $ git commit -am 'adding LAST_COMMIT file for archives'
 ----
@@ -317,7 +339,7 @@ $ git archive @ | tar xfO - LAST_COMMIT
 Last commit: 312ccc8 by Jim Hill at Fri May 8 09:14:04 2015 -0700
        export-subst uses git log's custom formatter
 
-         git archive uses git log's `pretty=format:` processor directly, and 
+         git archive uses git log's `pretty=format:` processor directly, and
          strips the surrounding `$Format:` and `$` markup from the output.
 ----
 


### PR DESCRIPTION
All modifications to the .gitattributes file are now illustrated using `[source,ini]` blocks. Previously it was a mishmash of `[source,ini]` and `[source,console] $echo foo >> .gitattributes` commands.