### PR TITLE
Replace hardcoded incorrect reference to Chapter 6

### DIFF
--- a/book/08-customizing-git/sections/policy.asc
+++ b/book/08-customizing-git/sections/policy.asc
@@ -427,7 +427,7 @@ target_shas.each do |sha|
   end
 end
 ----
-This script uses a syntax that wasn't covered in the Revision Selection section of Chapter 6. You get a list of commits that have already been pushed up by running this:
+This script uses a syntax that wasn't covered in the <<_revision_selection>> section of <<_git_tools>>. You get a list of commits that have already been pushed up by running this:
 
 [source,ruby]
 ----

--- a/book/08-customizing-git/sections/policy.asc
+++ b/book/08-customizing-git/sections/policy.asc
@@ -427,7 +427,7 @@ target_shas.each do |sha|
   end
 end
 ----
-This script uses a syntax that wasn't covered in the <<_revision_selection>> section of <<_git_tools>>. You get a list of commits that have already been pushed up by running this:
+This script uses a syntax that wasn't covered in <<_revision_selection>>. You get a list of commits that have already been pushed up by running this:
 
 [source,ruby]
 ----


### PR DESCRIPTION
Updated policy.asc in Chapter 8 to use a link to the relevant section in Chapter 7 rather than a hardcoded and incorrect reference to Chapter 6.