### PR TITLE
Fix 'dependant' typo in first-time-setup.asc

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -41,7 +41,7 @@ Many of the GUI tools will help you do this when you first run them.
 ==== Your Editor
 
 Now that your identity is set up, you can configure the default text editor that will be used when Git needs you to type in a message.
-If not configured, Git uses your system's default editor, which is system dependant.
+If not configured, Git uses your system's default editor.
 
 If you want to use a different text editor, such as Emacs, you can do the following:
 
@@ -55,12 +55,12 @@ While on a Windows system, if you want to use a different text editor, such as N
 On a x86 system
 [source,console]
 ----
-$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession" 
+$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
 On a x64 system
 [source,console]
 ----
-$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession" 
+$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
 
 [NOTE]


### PR DESCRIPTION
Deleted a redundant sentence fragment rather than directly fix the typo.