### PR TITLE
Capitalize Version Control System for consistency

### DIFF
--- a/book/01-introduction/1-introduction.asc
+++ b/book/01-introduction/1-introduction.asc
@@ -21,6 +21,6 @@ include::sections/help.asc[]
 
 === Summary
 
-You should have a basic understanding of what Git is and how it's different from the centralized version control system you may have previously been using.
+You should have a basic understanding of what Git is and how it's different from the Centralized Version Control System you may have previously been using.
 You should also now have a working version of Git on your system that's set up with your personal identity.
 It's now time to learn some Git basics.

--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -5,7 +5,7 @@ Merging in Git is typically fairly easy.
 Since Git makes it easy to merge another branch multiple times, it means that you can have a very long lived branch but you can keep it up to date as you go, solving small conflicts often, rather than be surprised by one enormous conflict at the end of the series.
 
 However, sometimes tricky conflicts do occur.
-Unlike some other version control systems, Git does not try to be overly clever about merge conflict resolution.
+Unlike some other Version Control Systems, Git does not try to be overly clever about merge conflict resolution.
 Git's philosophy is to be smart about determining when a merge resolution is unambiguous, but if there is a conflict, it does not try to be clever about automatically resolving it.
 Therefore, if you wait too long to merge two branches that diverge quickly, you can run into some issues.
 

--- a/book/09-git-and-other-scms/sections/client-tfs.asc
+++ b/book/09-git-and-other-scms/sections/client-tfs.asc
@@ -362,7 +362,7 @@ Notice how after every successful checkin to the TFVC server, git-tfs is rebasin
 That's because it's adding the `git-tfs-id` field to the bottom of the commit messages, which changes the SHA-1 hashes.
 This is exactly as designed, and there's nothing to worry about, but you should be aware that it's happening, especially if you're sharing Git commits with others.
 
-TFS has many features that integrate with its version control system, such as work items, designated reviewers, gated checkins, and so on.
+TFS has many features that integrate with its Version Control System, such as work items, designated reviewers, gated checkins, and so on.
 It can be cumbersome to work with these features using only a command-line tool, but fortunately git-tfs lets you launch a graphical checkin tool very easily:
 
 [source,powershell]

--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -19,13 +19,13 @@ cherry-pick       -- apply changes introduced by some existing commits
 Ambiguous tab-completions aren't just listed; they have helpful descriptions, and you can graphically navigate the list by repeatedly hitting tab.
 This works with Git commands, their arguments, and names of things inside the repository (like refs and remotes), as well as filenames and all the other things Zsh knows how to tab-complete.
 
-Zsh ships with a framework for getting information from version control systems, called `vcs_info`.
+Zsh ships with a framework for getting information from Version Control Systems, called `vcs_info`.
 To include the branch name in the prompt on the right side, add these lines to your `~/.zshrc` file:
 
 [source,console]
 ----
 autoload -Uz vcs_info
-precmd_vcs_info() { vcs_info } 
+precmd_vcs_info() { vcs_info }
 precmd_functions+=( precmd_vcs_info )
 setopt prompt_subst
 RPROMPT=\$vcs_info_msg_0_

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -477,18 +477,18 @@ We demonstrate how to use `git request-pull` to generate a pull message in <<_pu
 
 === External Systems
 
-Git comes with a few commands to integrate with other version control systems.
+Git comes with a few commands to integrate with other Version Control Systems.
 
 ==== git svn
 
-The `git svn` command is used to communicate with the Subversion version control system as a client.
+The `git svn` command is used to communicate with the Subversion Version Control System as a client.
 This means you can use Git to checkout from and commit to a Subversion server.
 
 This command is covered in depth in <<_git_svn>>.
 
 ==== git fast-import
 
-For other version control systems or importing from nearly any format, you can use `git fast-import` to quickly map the other format to something Git can easily record.
+For other Version Control Systems or importing from nearly any format, you can use `git fast-import` to quickly map the other format to something Git can easily record.
 
 This command is covered in depth in <<_custom_importer>>.
 


### PR DESCRIPTION
To be consistent with Chapter 1, capitalize the rest of the occurrences of "centralized version control system" and "version control system" throughout the rest of the text.