### PR TITLE
Fix `git stash` examples

### DIFF
--- a/book/07-git-tools/sections/stashing-cleaning.asc
+++ b/book/07-git-tools/sections/stashing-cleaning.asc
@@ -67,13 +67,15 @@ If you don’t specify a stash, Git assumes the most recent stash and tries to a
 [source,console]
 ----
 $ git stash apply
-# On branch master
-# Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#
-#      modified:   index.html
-#      modified:   lib/simplegit.rb
-#
+On branch master
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+	modified:   index.html
+	modified:   lib/simplegit.rb
+
+no changes added to commit (use "git add" and/or "git commit -a")
 ----
 
 You can see that Git re-modifies the files you reverted when you saved the stash.
@@ -88,17 +90,17 @@ If you had run that instead, you’d have gotten back to your original position:
 [source,console]
 ----
 $ git stash apply --index
-# On branch master
-# Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
-#
-#      modified:   index.html
-#
-# Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#
-#      modified:   lib/simplegit.rb
-#
+On branch master
+Changes to be committed:
+  (use "git reset HEAD <file>..." to unstage)
+
+	modified:   index.html
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+	modified:   lib/simplegit.rb
 ----
 
 The apply option only tries to apply the stashed work – you continue to have it on your stack.
@@ -191,19 +193,22 @@ If you want an easier way to test the stashed changes again, you can run `git st
 [source,console]
 ----
 $ git stash branch testchanges
-Switched to a new branch "testchanges"
-# On branch testchanges
-# Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
-#
-#      modified:   index.html
-#
-# Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#
-#      modified:   lib/simplegit.rb
-#
-Dropped refs/stash@{0} (f0dfc4d5dc332d1cee34a634182e168c4efc3359)
+M	index.html
+M	lib/simplegit.rb
+Switched to a new branch 'testchanges'
+On branch testchanges
+Changes to be committed:
+  (use "git reset HEAD <file>..." to unstage)
+
+	modified:   index.html
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+	modified:   lib/simplegit.rb
+
+Dropped refs/stash@{0} (29d385a81d163dfd45a452a2ce816487a6b8b014)
 ----
 
 This is a nice shortcut to recover stashed work easily and work on it in a new branch.


### PR DESCRIPTION
The console output for these `git stash` examples didn't reflect reality.