### PR TITLE
Strip "origin/" prefix from branch name

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -86,8 +86,8 @@ Next, move the rest of the references under `refs/remotes` to be local branches:
 
 [source,console]
 ----
-$ cp -Rf .git/refs/remotes/* .git/refs/heads/
-$ rm -Rf .git/refs/remotes
+$ cp -Rf .git/refs/remotes/origin/* .git/refs/heads/
+$ rm -Rf .git/refs/remotes/origin
 ----
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.


### PR DESCRIPTION
git svn clones prefixes all SVN branch names by "origin/" in git, which is not wanted when migrating from svn to git. Hence, the prefix has to be stripped, simply in the same way it is done for tags already.