### PR TITLE
Remove duplicate 'trunk' branch

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -92,7 +92,7 @@ $ rm -Rf .git/refs/remotes
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 
-Unfortunately `git svn` creates one extra branch named `trunk` for svn's trunk, which is essentially the same as the already created `master` branch (it actually refers to the same commit). Hence, let's remove this doublet:
+There's one last thing to clean up. Unfortunately, git svn creates an extra branch named trunk, which maps to Subversion's default branch, but the trunk ref points to the same place as master. Since master is more idiomatically Git, here's how to remove the extra branch:
 
 [source,console]
 ----

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -91,6 +91,14 @@ $ rm -Rf .git/refs/remotes
 ----
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
+
+Unfortunately `git svn` creates one extra branch named `trunk` for svn's trunk, which is essentially the same as the already created `master` branch (it actually refers to the same commit). Hence, let's remove this doublet:
+
+[source,console]
+----
+$ git branch -d trunk
+----
+
 The last thing to do is add your new Git server as a remote and push to it.
 Here is an example of adding your server as a remote:
 

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -92,7 +92,7 @@ $ rm -Rf .git/refs/remotes
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 
-There's one last thing to clean up. Unfortunately, git svn creates an extra branch named trunk, which maps to Subversion's default branch, but the trunk ref points to the same place as master. Since master is more idiomatically Git, here's how to remove the extra branch:
+There's one last thing to clean up. Unfortunately, `git svn` creates an extra branch named `trunk`, which maps to Subversion's default branch, but the `trunk` ref points to the same place as `master`. Since `master` is more idiomatically Git, here's how to remove the extra branch:
 
 [source,console]
 ----


### PR DESCRIPTION
svn git creates 'trunk' branch which points to the same commit as 'master' which is simpy misleading. Let's just remove it!