### PR TITLE
How to deal with peg-revisions

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -90,7 +90,7 @@ $ cp -Rf .git/refs/remotes/* .git/refs/heads/
 $ rm -Rf .git/refs/remotes
 ----
 
-It may happen that you'll see some extra branches which are suffixed by @xxx (where xxx is a number), while in Subversion you only see one branch. This is actually a Subversion feature called "peg-revisions", which is something that Git simply has no syntactical counterpart for. Hence, git svn simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about the peg-revisions, simply remove them using git branch -d.
+It may happen that you'll see some extra branches which are suffixed by `@xxx` (where xxx is a number), while in Subversion you only see one branch. This is actually a Subversion feature called "peg-revisions", which is something that Git simply has no syntactical counterpart for. Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about the peg-revisions, simply remove them using `git branch -d`.
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 The last thing to do is add your new Git server as a remote and push to it.

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -90,7 +90,7 @@ $ cp -Rf .git/refs/remotes/* .git/refs/heads/
 $ rm -Rf .git/refs/remotes
 ----
 
-It may happen that a branch is created *multiply*, suffixed by `@xxx` (where xxx is a number), while in svn you only see *one* branch. This is not a fault, but actually the solution to keep so-called "peg-revisions", which is a feature of svn that git simply has no syntactical counterpart for. Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about that peg-revisions, simply remove them using `git branch -d`.
+It may happen that you'll see some extra branches which are suffixed by @xxx (where xxx is a number), while in Subversion you only see one branch. This is actually a Subversion feature called "peg-revisions", which is something that Git simply has no syntactical counterpart for. Hence, git svn simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about the peg-revisions, simply remove them using git branch -d.
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 The last thing to do is add your new Git server as a remote and push to it.

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -90,6 +90,8 @@ $ cp -Rf .git/refs/remotes/* .git/refs/heads/
 $ rm -Rf .git/refs/remotes
 ----
 
+It may happen that a branch is created *multiply*, suffixed by `@xxx` (where xxx is a number), while in svn you only see *one* branch. This is not a fault, but actually the solution to keep so-called "peg-revisions", which is a feature of svn that git simply has no syntactical counterpart for. Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about that peg-revisions, simply remove them using `git branch -d`.
+
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 The last thing to do is add your new Git server as a remote and push to it.
 Here is an example of adding your server as a remote:


### PR DESCRIPTION
It is not a fault that peg-revisions will result in multiple branches when migrating svn to git.