### PR TITLE
Remove superfluous phrase.

### DIFF
--- a/book/07-git-tools/sections/subtree-merges.asc
+++ b/book/07-git-tools/sections/subtree-merges.asc
@@ -1,7 +1,7 @@
 [[_subtree_merge]]
 ===== Subtree Merging
 
-The idea of the subtree merge is that you have two projects, and one of the projects maps to a subdirectory of the other one and vice versa.
+The idea of the subtree merge is that you have two projects, and one of the projects maps to a subdirectory of the other one.
 When you specify a subtree merge, Git is often smart enough to figure out that one is a subtree of the other and merge appropriately.
 
 We'll go through an example of adding a separate project into an existing project and then merging the code of the second into a subdirectory of the first.


### PR DESCRIPTION
The superfluous "and vice versa" is incorrect here -- the two projects
/don't/ each have the other as subdirectories.  In fact only one has the
other as a subdirectory.

Fixes #486.