### PR TITLE
git push --all does not push tags

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -104,6 +104,7 @@ Because you want all your branches and tags to go up, you can now run this:
 [source,console]
 ----
 $ git push origin --all
+$ git push origin --tags
 ----
 
 All your branches and tags should be on your new Git server in a nice, clean import.


### PR DESCRIPTION
It is incorrect that git push origin -all would push tags on the git server. Actually you have to do git push --tags to also push the tags.