### PR TITLE
Make output of `git log` consistent with preceding figure

### DIFF
--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -80,9 +80,9 @@ This option is called `--decorate`.
 [source,console]
 ----
 $ git log --oneline --decorate
-f30ab (HEAD, master, testing) add feature #32 - ability to add new
-34ac2 fixed bug #1328 - stack overflow under certain conditions
-98ca9 initial commit of my project
+f30ab (HEAD -> master, testing) add feature #32 - ability to add new formats to the central interface
+34ac2 Fixed bug #1328 - stack overflow under certain conditions
+98ca9 The initial commit of my project
 ----
 
 You can see the ``master'' and ``testing'' branches that are right there next to the `f30ab` commit.


### PR DESCRIPTION
Make commit messages consistent with the preceding figure and correct the `(HEAD -> master, testing)` `--decorate` output.