### PR TITLE
More accurate explanation for git log example

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -273,7 +273,7 @@ In <<limit_options>> we'll list these and a few other common options for your re
 | `-S`                  | Only show commits adding or removing code matching the string
 |================================
 
-For example, if you want to see which commits modifying test files in the Git source code history were committed by Junio Hamano and are merged and were committed in the month of October 2008, you can run something like this:(((log filtering)))
+For example, if you want to see which commits modifying test files in the Git source code history are merged and were committed by Junio Hamano in the month of October 2008, you can run something like this:(((log filtering)))
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -273,7 +273,7 @@ In <<limit_options>> we'll list these and a few other common options for your re
 | `-S`                  | Only show commits adding or removing code matching the string
 |================================
 
-For example, if you want to see which commits modifying test files in the Git source code history were committed by Junio Hamano and were not merged in the month of October 2008, you can run something like this:(((log filtering)))
+For example, if you want to see which commits modifying test files in the Git source code history were committed by Junio Hamano and are merged and were committed in the month of October 2008, you can run something like this:(((log filtering)))
 
 [source,console]
 ----


### PR DESCRIPTION
In section 2.3 Git Basics - Viewing the Commit History, the final example is: `git log --pretty="%h - %s" --author=gitster --since="2008-10-01" \
   --before="2008-11-01" --no-merges`. The explanation says
> and were not merged in the month of October 2008

If I understand correctly the documentation in
>--no-merges
           Do not print commits with more than one parent. This is exactly the same as --max-parents=1.

this means that the merge commits themselves will be excluded. So if a commit occured in Oct, but merged in Nov it will still be shown in the output.
