### PR TITLE
avoid fetching subtree's tags into project's tagspace

### DIFF
--- a/book/07-git-tools/sections/subtree-merges.asc
+++ b/book/07-git-tools/sections/subtree-merges.asc
@@ -12,7 +12,7 @@ We'll add the Rack project as a remote reference in our own project and then che
 [source,console]
 ----
 $ git remote add rack_remote https://github.com/rack/rack
-$ git fetch rack_remote
+$ git fetch rack_remote --no-tags
 warning: no common commits
 remote: Counting objects: 3184, done.
 remote: Compressing objects: 100% (1465/1465), done.


### PR DESCRIPTION
Most people won't want to intermingle the subtree project's tags with their own.