### PR TITLE
Full sha1 value

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -378,7 +378,7 @@ If you want to pull commit `e43a6` into your master branch, you can run
 
 [source,console]
 ----
-$ git cherry-pick e43a6fd3e94888d76779ad79fb568ed180e5fcdf
+$ git cherry-pick e43a6
 Finished one cherry-pick.
 [master]: created a0a41a9: "More friendly message when locking the index fails."
  3 files changed, 17 insertions(+), 3 deletions(-)


### PR DESCRIPTION
Do we really need to use the full e43a6fd3e94888d76779ad79fb568ed180e5fcdf value in git cherry-pick e43a6fd3e94888d76779ad79fb568ed180e5fcdf . Couldn't it be git cherry-pick e43a6 ?