### PR TITLE
Fix explanation of upstream branch

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -130,7 +130,7 @@ This gives you a local branch that you can work on that starts where `origin/ser
 ==== Tracking Branches
 
 (((branches, tracking)))(((branches, upstream)))
-Checking out a local branch from a remote-tracking branch automatically creates what is called a ``tracking branch'' (or sometimes an ``upstream branch'').
+Checking out a local branch from a remote-tracking branch automatically creates what is called a ``tracking branch'' (and the branch it tracks is called an ``upstream branch'').
 Tracking branches are local branches that have a direct relationship to a remote branch.
 If you're on a tracking branch and type `git pull`, Git automatically knows which server to fetch from and branch to merge into.
 
@@ -177,7 +177,7 @@ Branch serverfix set up to track remote branch serverfix from origin.
 [NOTE]
 .Upstream shorthand
 ====
-When you have a tracking branch set up, you can reference it with the `@{upstream}` or `@{u}` shorthand.
+When you have a tracking branch set up, you can reference its upstream branch with the `@{upstream}` or `@{u}` shorthand.
 So if you're on the `master` branch and it's tracking `origin/master`, you can say something like `git merge @{u}` instead of `git merge origin/master` if you wish.(((+++@{u}+++)))(((+++@{upstream}+++)))
 ====
 


### PR DESCRIPTION
A tracking branch is not an upstream of something.

Back in pre-git-v1.7 era “tracking branch” also meant remote-tracking branch, and that kind of tracking branch was often an upstream of a local branch.

Today the terminology has been clarified, so a “tracking branch” usually is (at least in the rest of this section) a local branch that tracks an upstream branch.