### PR TITLE
Fix issue #526: There is no *adding* remote repositories in previous sections.

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -63,7 +63,8 @@ Notice that these remotes use a variety of protocols; we'll cover more about thi
 
 ==== Adding Remote Repositories
 
-We've mentioned and given some demonstrations of adding remote repositories in previous sections, but here is how to do it explicitly.(((git commands, remote)))
+We've mentioned and given some demonstrations of how the 'clone' command implicitly adds the `origin` remote for you.
+Here's how to add a new remote explicitly.(((git commands, remote)))
 To add a new remote Git repository as a shortname you can reference easily, run `git remote add <shortname> <url>`:
 
 [source,console]


### PR DESCRIPTION
There is no `git add remote`, related command, or statement in previous sections, but `git clone`.
And the only remote repository mentioned is "origin" which is added automatically via clone command.
Fix the sentence for that.

Only one question: the words `directly` vs. `explicitly`. **Which one is better?**