### PR TITLE
Remove --detach from local-git-daemon.conf

### DIFF
--- a/book/04-git-server/sections/git-daemon.asc
+++ b/book/04-git-server/sections/git-daemon.asc
@@ -37,7 +37,6 @@ stop on shutdown
 exec /usr/bin/git daemon \
     --user=git --group=git \
     --reuseaddr \
-    --detach \
     --base-path=/opt/git/ \
     /opt/git/
 respawn


### PR DESCRIPTION
--detach will fork and trigger an endless loop of respawns
If --detach is used you probably want to specify

expect fork[1]

[1] http://upstart.ubuntu.com/cookbook/#expect-fork