### PR TITLE
Fix issue #534: `git remote rename` does not rename *a* reference

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -193,7 +193,7 @@ It also shows you which remote branches on the server you don't yet have, which 
 
 ==== Removing and Renaming Remotes
 
-If you want to rename a reference you can run `git remote rename` to change a remote's shortname.(((git commands, remote)))
+You can run `git remote rename` to change a remote's shortname.(((git commands, remote)))
 For instance, if you want to rename `pb` to `paul`, you can do so with `git remote rename`:
 
 [source,console]
@@ -204,7 +204,7 @@ origin
 paul
 ----
 
-It's worth mentioning that this changes your remote branch names, too.
+It's worth mentioning that this changes all your remote-tracking branch names, too.
 What used to be referenced at `pb/master` is now at `paul/master`.
 
 If you want to remove a remote for some reason – you've moved the server or are no longer using a particular mirror, or perhaps a contributor isn't contributing anymore – you can use `git remote rm`:


### PR DESCRIPTION
Also fix "remote branch" to "remote-tracking branch".