### PR TITLE
git-credential-read-only should match against username

### DIFF
--- a/book/07-git-tools/git-credential-read-only
+++ b/book/07-git-tools/git-credential-read-only
@@ -22,7 +22,7 @@ end
 
 File.readlines(path).each do |fileline| # <4>
     prot,user,pass,host = fileline.scan(/^(.*?):\/\/(.*?):(.*?)@(.*)$/).first
-    if prot == known['protocol'] and host == known['host'] then
+    if prot == known['protocol'] and host == known['host'] and user == known['username'] then
         puts "protocol=#{prot}"
         puts "host=#{host}"
         puts "username=#{user}"


### PR DESCRIPTION
Hello,

In the current version, the first entry matching protocol/hostname and not protocol/username/hostname is returned.

For exemple:
.git-credentials:
```
http://titi:pwd1@exemple.com (1)
http://toto:pwd2@exemple.com (2)
```
then
```git clone http://toto@exemple.com``` will match (1) instead of (2).

