### PR TITLE
Fix cmdline in credentials.asc

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -36,7 +36,7 @@ Here's an example of how you'd configure the ``store'' helper with a custom file
 
 [source,console]
 ----
-$ git config --global credential.helper store --file ~/.my-credentials
+$ git config --global credential.helper 'store --file ~/.my-credentials'
 ----
 
 Git even allows you to configure several helpers.

--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -193,7 +193,7 @@ Since its name starts with ``git-'', we can use the simple syntax for the config
 
 [source,console]
 ----
-$ git config --global credential.helper read-only --file /mnt/shared/creds
+$ git config --global credential.helper 'read-only --file /mnt/shared/creds'
 ----
 
 As you can see, extending this system is pretty straightforward, and can solve some common problems for you and your team.


### PR DESCRIPTION
I tried the following example from the book and it just displayed the help for `git config`:

```
git config --global credential.helper store --file ~/.my-credentials
```

After a bit of research I found the [git-credential-store(1) Manual Page](https://git-scm.com/docs/git-credential-store/1.7.12.1) which actually puts single quotes around the `store --file ~/.my-credentials`, which worked for me. I'm using git version 1.9.1, not sure if that makes a difference.

Note that there's another example at the bottom of this page, `git config --global credential.helper read-only --file /mnt/shared/creds`, which might also require single quotes around its last part to work, but I'm not sure, so I didn't change that.