### PR TITLE
Add recommendation note

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -31,8 +31,7 @@ That generates the log output in XML format, then keeps only the lines with auth
 Then, redirect that output into your `users.txt` file so you can add the equivalent Git user data next to each entry.
 
 You can provide this file to `git svn` to help it map the author data more accurately.
-You can also tell `git svn` not to include the metadata that Subversion normally imports, by passing `--no-metadata` to the `clone` or `init` command.
-However this is not recommended because it breaks the two-way synchronisation between the git repository and the svn repository.
+You can also tell `git svn` not to include the metadata that Subversion normally imports, by passing `--no-metadata` to the `clone` or `init` command (though if you want to keep the synchronisation-metadata, feel free to omit this parameter).
 This makes your `import` command look like this:
 
 [source,console]

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -32,6 +32,7 @@ Then, redirect that output into your `users.txt` file so you can add the equival
 
 You can provide this file to `git svn` to help it map the author data more accurately.
 You can also tell `git svn` not to include the metadata that Subversion normally imports, by passing `--no-metadata` to the `clone` or `init` command.
+However this is not recommended because it breaks the two-way synchronisation between the git repository and the svn repository.
 This makes your `import` command look like this:
 
 [source,console]


### PR DESCRIPTION
#550 Add note that it is not recommended to use --no-metadata because it may breaks
synchronisation between git and svn.