### PR TITLE
Fix issue #554: The output of 'git status' is out-of-date

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -32,7 +32,7 @@ This means you have a clean working directory – in other words, there are no t
 Git also doesn't see any untracked files, or they would be listed here.
 Finally, the command tells you which branch you're on and informs you that it has not diverged from the same branch on the server.
 For now, that branch is always ``master'', which is the default; you won't worry about it here.
-<<_git_branching>>  will go over branches and references in detail.
+<<_git_branching>> will go over branches and references in detail.
 
 Let's say you add a new file to your project, a simple README file.
 If the file didn't exist before, and you run `git status`, you see your untracked file like so:

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -24,6 +24,7 @@ If you run this command directly after a clone, you should see something like th
 ----
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 nothing to commit, working directory clean
 ----
 
@@ -41,6 +42,7 @@ If the file didn't exist before, and you run `git status`, you see your untracke
 $ echo 'My Project' > README
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -71,6 +73,7 @@ If you run your status command again, you can see that your README file is now t
 ----
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -92,6 +95,7 @@ If you change a previously tracked file called `CONTRIBUTING.md` and then run yo
 ----
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -116,6 +120,7 @@ Let's run `git add` now to stage the `CONTRIBUTING.md` file, and then run `git s
 $ git add CONTRIBUTING.md
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -134,6 +139,7 @@ However, let's run `git status` one more time:
 $ vim CONTRIBUTING.md
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -160,6 +166,7 @@ If you modify a file after you run `git add`, you have to run `git add` again to
 $ git add CONTRIBUTING.md
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -263,6 +270,7 @@ If you run your `git status` command, you once again see something like this:
 ----
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -326,6 +334,7 @@ $ git add CONTRIBUTING.md
 $ echo '# test line' >> CONTRIBUTING.md
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -409,6 +418,8 @@ The editor displays the following text (this example is a Vim screen):
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master
+# Your branch is up-to-date with 'origin/master'.
+#
 # Changes to be committed:
 #	new file:   README
 #	modified:   CONTRIBUTING.md
@@ -453,6 +464,7 @@ Adding the `-a` option to the `git commit` command makes Git automatically stage
 ----
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -501,6 +513,7 @@ $ git rm PROJECTS.md
 rm 'PROJECTS.md'
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 
@@ -565,6 +578,7 @@ In fact, if you run something like this and look at the status, you'll see that 
 $ git mv README.md README
 $ git status
 On branch master
+Your branch is up-to-date with 'origin/master'.
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)
 


### PR DESCRIPTION
Fixes #554 and delete duplicate space.