### PR TITLE
Fix issue #384: There's no Git for Windows 2.x

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -18,7 +18,7 @@ Each level overrides values in the previous level, so values in `.git/config` tr
 
 On Windows systems, Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).
 It also still looks for `/etc/gitconfig`, although it's relative to the MSys root, which is wherever you decide to install Git on your Windows system when you run the installer.
-If you are using Git for Windows 2.x or later, there is also a system-level config file at
+If you are using version 2.x or later of Git for Windows, there is also a system-level config file at
 `C:\Documents and Settings\All Users\Application Data\Git\config` on Windows XP, and in `C:\ProgramData\Git\config` on Windows Vista and newer.
 This config file can only be changed by `git config -f <file>` as an admin.
 


### PR DESCRIPTION
Fixes #384 

Use "version 2.x of Git for Windows"