### PR TITLE
Fix git clone simplegit-progit https url

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -9,7 +9,7 @@ To get the project, run
 
 [source,console]
 ----
-$ git clone https://github.com/schacon/simplegit-progit
+$ git clone https://github.com/schacon/simplegit-progit.git
 ----
 
 When you run `git log` in this project, you should get output that looks something like this:(((git commands, log)))


### PR DESCRIPTION
I think the clone url with `.git` suffix is correct.