### PR TITLE
fix jgit javadoc link

### DIFF
--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -155,7 +155,7 @@ Many other commands are available through the Git class, including but not limit
 This is only a small sampling of JGit's full capabilities.
 If you're interested and want to learn more, here's where to look for information and inspiration:
 
-* The official JGit API documentation is available online at http://download.eclipse.org/jgit/docs/latest/apidocs[].
+* The official JGit API documentation is available online at http://download.eclipse.org/jgit/site/4.3.0.201604071810-r/apidocs/[].
   These are standard Javadoc, so your favorite JVM IDE will be able to install them locally, as well.
 * The JGit Cookbook at https://github.com/centic9/jgit-cookbook[] has many examples of how to do specific tasks with JGit.
 * There are several good resources pointed out at http://stackoverflow.com/questions/6861881[].

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -155,7 +155,7 @@ Many other commands are available through the Git class, including but not limit
 This is only a small sampling of JGit's full capabilities.
 If you're interested and want to learn more, here's where to look for information and inspiration:
 
-* The official JGit API documentation is available online at http://download.eclipse.org/jgit/site/4.3.0.201604071810-r/apidocs/[].
+* The official JGit API documentation can be found at http://www.eclipse.org/jgit/documentation/[].
   These are standard Javadoc, so your favorite JVM IDE will be able to install them locally, as well.
 * The JGit Cookbook at https://github.com/centic9/jgit-cookbook[] has many examples of how to do specific tasks with JGit.
 * There are several good resources pointed out at http://stackoverflow.com/questions/6861881[].


### PR DESCRIPTION
Unfortunately there is no generic javadoc link anymore.
I linked the latest stable version.
Old version docs are not removed so this should keep working.

The previous link leads to a project page and there is no link to the javadoc on that page.
