### PR TITLE
Harden retrieval of author list from Subversion

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -22,7 +22,7 @@ To get a list of the author names that SVN uses, you can run this:
 
 [source,console]
 ----
-$ svn log --xml | grep author | sort -u | \
+$ svn log --xml --quiet | grep author | sort -u | \
   perl -pe 's/.*>(.*?)<.*/$1 = /'
 ----
 


### PR DESCRIPTION
In order to get a list of authors from a Subversion repository,
we extract the authors from the output of `svn log --xml`. We
then try to filter out the author field by grepping for 'author'.
This produces incorrect results in the case where a commit's
message contains the word 'author'.

Fix the issue by invoking `svn log --xml --quiet` instead, which
suppresses the commit's message.