### PR TITLE
Update undoing.asc

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -34,7 +34,7 @@ You end up with a single commit – the second commit replaces the results of th
 [[_unstaging]]
 ==== Unstaging a Staged File
 
-The next two sections demonstrate how to wrangle your staging area and working directory changes.
+The next two sections demonstrate how to wangle your staging area and working directory changes.
 The nice part is that the command you use to determine the state of those two areas also reminds you how to undo changes to them.
 For example, let's say you've changed two files and want to commit them as two separate changes, but you accidentally type `git add *` and stage them both.
 How can you unstage one of the two?

--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -34,7 +34,7 @@ You end up with a single commit – the second commit replaces the results of th
 [[_unstaging]]
 ==== Unstaging a Staged File
 
-The next two sections demonstrate how to wangle your staging area and working directory changes.
+The next two sections demonstrate how to work with your staging area and working directory changes.
 The nice part is that the command you use to determine the state of those two areas also reminds you how to undo changes to them.
 For example, let's say you've changed two files and want to commit them as two separate changes, but you accidentally type `git add *` and stage them both.
 How can you unstage one of the two?


### PR DESCRIPTION
Corrected spelling mistake, according to the Wiktionary (when meaning “to falsify, as records”, the word is [wangle](https://en.wiktionary.org/wiki/wangle), not [wrangle](https://en.wiktionary.org/wiki/wrangle)).