### PR TITLE
linebreak deletion

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -201,7 +201,11 @@ Finally we can see that our `testing` branch is not tracking any remote branch.
 It's important to note that these numbers are only since the last time you fetched from each server.
 This command does not reach out to the servers, it's telling you about what it has cached from these servers locally.
 If you want totally up to date ahead and behind numbers, you'll need to fetch from all your remotes right before running this.
-You could do that like this: `git fetch --all; git branch -vv`
+You could do that like this:
+[source,console]
+----
+$ git fetch --all; git branch -vv
+----
 
 ==== Pulling
 

--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -202,6 +202,7 @@ It's important to note that these numbers are only since the last time you fetch
 This command does not reach out to the servers, it's telling you about what it has cached from these servers locally.
 If you want totally up to date ahead and behind numbers, you'll need to fetch from all your remotes right before running this.
 You could do that like this:
+
 [source,console]
 ----
 $ git fetch --all; git branch -vv


### PR DESCRIPTION
In the PDF, page 113, a linebreak is automatically inserted after the dashes within the option “--all”, which makes ambiguous whether a space should be inserted or not.
(I made two commits because I made a mistake in the first commit and I’m not yet at ease with git, but the two commits are meant as a single one.)