### PR TITLE
Update submodules.asc

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -820,7 +820,7 @@ If you do remove it and then switch back to the branch that has that submodule, 
 
 [source,console]
 ----
-$ git clean -fdx
+$ git clean -ffdx
 Removing CryptoLibrary/
 
 $ git checkout add-crypto


### PR DESCRIPTION
Changed `git clean -fdx` to `git clean -ffdx` to ensure the submodule from the other branch actually gets removed.

Just using `git clean -fdx` would result in git skipping the repository during removals.