### PR TITLE
Adapted to current git version

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -37,7 +37,7 @@ This makes your `import` command look like this:
 [source,console]
 ----
 $ git svn clone http://my-project.googlecode.com/svn/ \
-      --authors-file=users.txt --no-metadata -s my_project
+      --authors-file=users.txt --no-metadata --prefix "" -s my_project
 ----
 
 Now you should have a nicer Subversion import in your `my_project` directory.
@@ -76,18 +76,16 @@ To move the tags to be proper Git tags, run:
 
 [source,console]
 ----
-$ cp -Rf .git/refs/remotes/origin/tags/* .git/refs/tags/
-$ rm -Rf .git/refs/remotes/origin/tags
+$ for t in $(git for-each-ref --format='%(refname:short)' refs/remotes/tags); do git tag ${t/tags\//} $t && git branch -D -r $t; done
 ----
 
-This takes the references that were remote branches that started with `remotes/origin/tags/` and makes them real (lightweight) tags.
+This takes the references that were remote branches that started with `refs/remotes/tags/` and makes them real (lightweight) tags.
 
 Next, move the rest of the references under `refs/remotes` to be local branches:
 
 [source,console]
 ----
-$ cp -Rf .git/refs/remotes/origin/* .git/refs/heads/
-$ rm -Rf .git/refs/remotes/origin
+$ for b in $(git for-each-ref --format='%(refname:short)' refs/remotes); do git branch $b refs/remotes/$b && git branch -D -r $b; done
 ----
 
 It may happen that you'll see some extra branches which are suffixed by `@xxx` (where xxx is a number), while in Subversion you only see one branch. This is actually a Subversion feature called "peg-revisions", which is something that Git simply has no syntactical counterpart for. Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch. If you do not care anymore about the peg-revisions, simply remove them using `git branch -d`.


### PR DESCRIPTION
The on-disk image of a git repository has changed in recent versions of w.r.t to how svn-git stores remote branches and tags. As a consequence the bash commands told in this section of the book did not work anymore. My proposal solves this issue. I tested it today against 2.1.4, so I assume the change happened with v2.0 or v2.1 and should work with newer Git versions, too.