### PR TITLE
Removing all peg revisions by one command

### DIFF
--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -91,7 +91,12 @@ $ for b in $(git for-each-ref --format='%(refname:short)' refs/remotes); do git 
 It may happen that you'll see some extra branches which are suffixed by `@xxx` (where xxx is a number), while in Subversion you only see one branch.
 This is actually a Subversion feature called ``peg-revisions'', which is something that Git simply has no syntactical counterpart for.
 Hence, `git svn` simply adds the svn version number to the branch name just in the same way as you would have written it in svn to address the peg-revision of that branch.
-If you do not care anymore about the peg-revisions, simply remove them using `git branch -d`.
+If you do not care anymore about the peg-revisions, simply remove them:
+
+[source,console]
+----
+$ for p in $(git for-each-ref --format='%(refname:short)' | grep @); do git branch -D $p; done
+----
 
 Now all the old branches are real Git branches and all the old tags are real Git tags.
 


### PR DESCRIPTION
Typically one wants to keep all peg-revisions or none, so I want to propose to give the exact code line for removing all peg-revisions at once.