### PR TITLE
Reference the 'push.recurseSubmodules' config in the section on pushing submodule changes

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -544,6 +544,8 @@ To https://github.com/chaconinc/MainProject
 As you can see there, Git went into the DbConnector module and pushed it before pushing the main project.
 If that submodule push fails for some reason, the main project push will also fail.
 
+You can enable these behaviors for all future pushes with the `push.recurseSubmodules` config.
+
 ===== Merging Submodule Changes
 
 If you change a submodule reference at the same time as someone else, you may run into some problems.

--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -518,6 +518,7 @@ to push them to a remote.
 
 As you can see, it also gives us some helpful advice on what we might want to do next.
 The simple option is to go into each submodule and manually push to the remotes to make sure they're externally available and then try this push again.
+If you want the check behavior to happen for all pushes, you can make this behavior the default by doing `git config push.recurseSubmodules check`.
 
 The other option is to use the ``on-demand'' value, which will try to do this for you.
 
@@ -543,8 +544,7 @@ To https://github.com/chaconinc/MainProject
 
 As you can see there, Git went into the DbConnector module and pushed it before pushing the main project.
 If that submodule push fails for some reason, the main project push will also fail.
-
-You can enable these behaviors for all future pushes with the `push.recurseSubmodules` config.
+You can make this behavior the default by doing `git config push.recurseSubmodules on-demand`.
 
 ===== Merging Submodule Changes
 


### PR DESCRIPTION
I was looking into submodules and subtrees recently, and one of the reasons I decided to go with submodules was because there was a config option that forced safer behavior for pushing submodule changes.

I figured it'd be nice if the section mentioned the config; hopefully this will help someone else consider using submodules if they can enforce a team wide use of the config.