### PR TITLE
Removed Posh-Git GitHub for Windows reference

### DIFF
--- a/book/A-git-in-other-environments/sections/powershell.asc
+++ b/book/A-git-in-other-environments/sections/powershell.asc
@@ -10,15 +10,7 @@ It looks like this:
 .Powershell with Posh-git.
 image::images/posh-git.png[Powershell with Posh-git.]
 
-If you've installed GitHub for Windows, Posh-Git is included by default, and all you have to do is add these lines to your `profile.ps1` (which is usually located in `C:\Users\<username>\Documents\WindowsPowerShell`):
-
-[source,powershell]
------
-. (Resolve-Path "$env:LOCALAPPDATA\GitHub\shell.ps1")
-. $env:github_posh_git\profile.example.ps1
------
-
-If you're not a GitHub for Windows user, just download a Posh-Git release from (https://github.com/dahlbyk/posh-git[]), and uncompress it to the `WindowsPowershell` directory.
+Just download a Posh-Git release from (https://github.com/dahlbyk/posh-git[]), and uncompress it to the `WindowsPowershell` directory.
 Then open a Powershell prompt as the administrator, and do this:
 
 [source,powershell]


### PR DESCRIPTION
I installed some of the latest GitHub for Windows versions on Windows 10 and no PoSh-Git gets installed, so i think this information deprecated.