### PR TITLE
Remove references to deleted googlecode.com domain

### DIFF
--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -30,7 +30,6 @@ If you're working with a team, and some are using SVN and others are using Git, 
 To demonstrate this functionality, you need a typical SVN repository that you have write access to.
 If you want to copy these examples, you'll have to make a writeable copy of my test repository.
 In order to do that easily, you can use a tool called `svnsync` that comes with Subversion.
-For these tests, we created a new Subversion repository on Google Code that was a partial copy of the `protobuf` project, which is a tool that encodes structured data for network transmission.
 
 To follow along, you first need to create a new local Subversion repository:
 
@@ -55,7 +54,7 @@ You can now sync this project to your local machine by calling `svnsync init` wi
 [source,console]
 ----
 $ svnsync init file:///tmp/test-svn \
-  http://progit-example.googlecode.com/svn/
+  http://your-svn-server.example.org/svn/
 ----
 
 This sets up the properties to run the sync.


### PR DESCRIPTION
Remove references to the nonexistent progit-example.googlecode.com domain. I can't see standing up that example repo given the limited value of the exercise.

Fixes #631 
