### PR TITLE
Update first-time-setup.asc

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -52,12 +52,12 @@ $ git config --global core.editor emacs
 
 While on a Windows system, if you want to use a different text editor, such as Notepad++, you can do the following:
 
-On a x86 system
+On a x64 system
 [source,console]
 ----
 $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
-On a x64 system
+On a x86 system
 [source,console]
 ----
 $ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"


### PR DESCRIPTION
Exchange the x64 with the x86 system headline that desribes the usage of another text editor on a windows system.