### PR TITLE
Remove quote escape.

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -286,7 +286,7 @@ So, you can either run four config commands
 ----
 $ git config --global merge.tool extMerge
 $ git config --global mergetool.extMerge.cmd \
-  'extMerge \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"'
+  'extMerge "$BASE" "$LOCAL" "$REMOTE" "$MERGED"'
 $ git config --global mergetool.extMerge.trustExitCode false
 $ git config --global diff.external extDiff
 ----


### PR DESCRIPTION
Escaping the quotes causes errors. Double quotes should not be escaped because the command is surrounded by single quotes.