### PR TITLE
Update git reset --hard note for clarity

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -79,7 +79,7 @@ The `CONTRIBUTING.md` file is modified but once again unstaged.
 
 [NOTE]
 =====
-While `git reset` _can_ be a dangerous command if you call it with `--hard`, in this instance the file in your working directory is not touched.
+While `git reset` _can_ be a dangerous command if you call it with `--hard` as it changes files in your working directory, however in the above example the file in your working directory is not touched.
 Calling `git reset` without an option is not dangerous - it only touches your staging area.
 =====
 

--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -79,8 +79,8 @@ The `CONTRIBUTING.md` file is modified but once again unstaged.
 
 [NOTE]
 =====
-While `git reset` _can_ be a dangerous command if you call it with `--hard` as it changes files in your working directory, however in the above example the file in your working directory is not touched.
-Calling `git reset` without an option is not dangerous - it only touches your staging area.
+It's true that `git reset` can be a dangerous command, especially if you provide the `--hard` flag.
+However, in the scenario described above, the file in your working directory is not touched, so it's relatively safe.
 =====
 
 For now this magic invocation is all you need to know about the `git reset` command.


### PR DESCRIPTION
The note is confusing as the example before it does not use `git reset --hard`. This was mentioned in closed issue #547.