### PR TITLE
Add git remote remove command

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -208,11 +208,11 @@ paul
 It's worth mentioning that this changes all your remote-tracking branch names, too.
 What used to be referenced at `pb/master` is now at `paul/master`.
 
-If you want to remove a remote for some reason – you've moved the server or are no longer using a particular mirror, or perhaps a contributor isn't contributing anymore – you can use `git remote rm`:
+If you want to remove a remote for some reason – you've moved the server or are no longer using a particular mirror, or perhaps a contributor isn't contributing anymore – you can either use `git remote remove` or `git remote rm`:
 
 [source,console]
 ----
-$ git remote rm paul
+$ git remote remove paul
 $ git remote
 origin
 ----


### PR DESCRIPTION
Most of the `git remote` command names are verbs e.g add, show, rename etc. It's a good idea to add `git remote remove` as the first one. Easy to remember with other commands (add/remove). Hence I also updated the example.