### PR TITLE
8.2: Surround docx path with quotes

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -71,7 +71,7 @@ Create a file that's somewhere in your path called `docx2txt`, and add these con
 [source,console]
 ----
 #!/bin/bash
-docx2txt.pl $1 -
+docx2txt.pl "$1" -
 ----
 
 Don't forget to `chmod a+x` that file.


### PR DESCRIPTION
Paths and filenames containing spaces would not be diffed without the
quotes