### PR TITLE
added escaped quotation marks for git commit's message.

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -329,9 +329,9 @@ The substitutions can include for example the commit message and any `git notes`
 [source,console]
 ----
 $ echo '$Format:Last commit: %h by %aN at %cd%n%+w(76,6,9)%B$' > LAST_COMMIT
-$ git commit -am 'export-subst uses git log's custom formatter
+$ git commit -am 'export-subst uses git log'\''s custom formatter
 
-git archive uses git log's `pretty=format:` processor
+git archive uses git log'\''s `pretty=format:` processor
 directly, and strips the surrounding `$Format:` and `$`
 markup from the output.
 '


### PR DESCRIPTION
It is necessary to escape quotation marks in the git message, otherwise it ends the commit's message.