### PR TITLE
Clarify explanation of configuring core.whitespace

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -422,12 +422,12 @@ The three that are disabled by default but can be turned on are `indent-with-non
 
 You can tell Git which of these you want enabled by setting `core.whitespace` to the values you want on or off, separated by commas.
 You can disable settings by either leaving them out of the setting string or prepending a `-` in front of the value.
-For example, if you want all but `cr-at-eol` to be set, you can do this:
+For example, if you want all but `cr-at-eol` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
 
 [source,console]
 ----
 $ git config --global core.whitespace \
-    trailing-space,space-before-tab,indent-with-non-tab
+    trailing-space,space-before-tab,indent-with-non-tab,tab-in-indent
 ----
 
 Git will detect these issues when you run a `git diff` command and try to color them so you can possibly fix them before you commit.


### PR DESCRIPTION
The switch `trailing-space` was used without mentioning what it means, and I think the command didn't set `tab-in-indent`.

Besides, after some trying, I find that "leaving them out of the setting string" doesn't disable the settings, but will only keep the default value unchanged. For example, if I want all but `cr-at-eol` to be set, I can simply do: `git config --global core.whitespace indent-with-non-tab,tab-in-indent`.

Maybe we can confirm the behavior and add more clarification for this part.