### PR TITLE
Correct wrong statement on whitespace config

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -421,7 +421,7 @@ The three that are turned on by default are `blank-at-eol`, which looks for spac
 The three that are disabled by default but can be turned on are `indent-with-non-tab`, which looks for lines that begin with spaces instead of tabs (and is controlled by the `tabwidth` option); `tab-in-indent`, which watches for tabs in the indentation portion of a line; and `cr-at-eol`, which tells Git that carriage returns at the end of lines are OK.
 
 You can tell Git which of these you want enabled by setting `core.whitespace` to the values you want on or off, separated by commas.
-You can disable settings by prepending a `-` in front of the value, or use default value of settings by leaving them out of the setting string.
+You can disable an option by prepending a `-` in front of its name, or use the default value by leaving it out of the setting string entirely.
 For example, if you want all but `space-before-tab` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
 
 [source,console]

--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -421,7 +421,7 @@ The three that are turned on by default are `blank-at-eol`, which looks for spac
 The three that are disabled by default but can be turned on are `indent-with-non-tab`, which looks for lines that begin with spaces instead of tabs (and is controlled by the `tabwidth` option); `tab-in-indent`, which watches for tabs in the indentation portion of a line; and `cr-at-eol`, which tells Git that carriage returns at the end of lines are OK.
 
 You can tell Git which of these you want enabled by setting `core.whitespace` to the values you want on or off, separated by commas.
-You can disable settings by prepending a - in front of the value, or use default value of settings by leaving them out of the setting string.
+You can disable settings by prepending a `-` in front of the value, or use default value of settings by leaving them out of the setting string.
 For example, if you want all but `space-before-tab` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
 
 [source,console]

--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -421,13 +421,21 @@ The three that are turned on by default are `blank-at-eol`, which looks for spac
 The three that are disabled by default but can be turned on are `indent-with-non-tab`, which looks for lines that begin with spaces instead of tabs (and is controlled by the `tabwidth` option); `tab-in-indent`, which watches for tabs in the indentation portion of a line; and `cr-at-eol`, which tells Git that carriage returns at the end of lines are OK.
 
 You can tell Git which of these you want enabled by setting `core.whitespace` to the values you want on or off, separated by commas.
-You can disable settings by either leaving them out of the setting string or prepending a `-` in front of the value.
-For example, if you want all but `cr-at-eol` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
+You can disable settings by prepending a - in front of the value, or use default value of settings by leaving them out of the setting string.
+For example, if you want all but `space-before-tab` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
 
 [source,console]
 ----
 $ git config --global core.whitespace \
-    trailing-space,space-before-tab,indent-with-non-tab,tab-in-indent
+    trailing-space,-space-before-tab,indent-with-non-tab,tab-in-indent,cr-at-eol
+----
+
+Or you can specify the customizing part only:
+
+[source,console]
+----
+$ git config --global core.whitespace \
+    -space-before-tab,indent-with-non-tab,tab-in-indent,cr-at-eol
 ----
 
 Git will detect these issues when you run a `git diff` command and try to color them so you can possibly fix them before you commit.


### PR DESCRIPTION
Well, this is actually a followup of https://github.com/progit/progit2/pull/698 .

As mentioned in that PR, I found that "leaving them out of the setting string" doesn't disable the settings, but will only keep the default value unchanged. Commits in this PR try to reflect that.