### PR TITLE
Monospaced a word in picture's caption to fix #598

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -53,8 +53,8 @@ $ vim index.html
 $ git commit -a -m 'added a new footer [issue 53]'
 ----
 
-.The iss53 branch has moved forward with your work
-image::images/basic-branching-3.png[The iss53 branch has moved forward with your work.]
+.The `iss53` branch has moved forward with your work
+image::images/basic-branching-3.png[The `iss53` branch has moved forward with your work.]
 
 Now you get the call that there is an issue with the website, and you need to fix it immediately.
 With Git, you don't have to deploy your fix along with the `iss53` changes you've made, and you don't have to put a lot of effort into reverting those changes before you can work on applying your fix to what is in production.


### PR DESCRIPTION
A picture in chapter 3 had a branch name that was not previously monospaced. This commit monospaces that word to maintain consistency with other parts of the book