### PR TITLE
Remove references to Atlas.

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -8,7 +8,6 @@ Like the first edition, the second edition of Pro Git is open source under a Cre
 
 A couple of things have changed since open sourcing the first edition.
 For one, we've moved from Markdown to the amazing Asciidoc format for the text of the book.
-We've also moved to using O'Reilly's https://atlas.oreilly.com[Atlas platform] for generating continuous builds of the book so all major formats are always available in every language.
 
 We've also moved to keeping the translations in separate repositories rather than subdirectories of the English repository.
 See link:CONTRIBUTING.md[the Contributing document] for more information.
@@ -20,7 +19,7 @@ There are two ways to generate e-book content from this source code.
 The easiest way is simply to let us do it.
 A robot is standing by to look for new work on the main branch and automatically build it for everyone.
 
-You can find the current builds on http://git-scm.com/book[] and more information about the builds available at https://progit.org[].
+You can find the current builds on http://git-scm.com/book[].
 
 The other way to generate e-book files is to do so manually with Asciidoctor.
 If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
@@ -44,7 +43,7 @@ This uses the `asciidoctor`, `asciidoctor-pdf` and `asciidoctor-epub` projects.
 
 Before signaling an issue, please check that there isn't already a similar one in the bug tracking system.
 
-Also, if this issue has been spotted on the git-scm.com site, please cross-check that it is still present in the pdf version.
+Also, if this issue has been spotted on the git-scm.com site, please cross-check that it is still present in this repo.
 The issue may have already been corrected, but the changes have not been deployed yet.
 
 == Contributing


### PR DESCRIPTION
The build is no longer performed by Atlas. We are on our own for publishing.

@ben do we need more on this?