### PR TITLE
2-contributing.asc: sed command fix/type

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -72,7 +72,8 @@ $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
 $ sed -i '' 's/1000/3000/' blink.ino <3> (MacOSX)
-$ sed -i 's/1000/3000/' blink.ino <3> (Linux)
+# If you're on a Linux system, do this instead:
+# $ sed -i 's/1000/3000/' blink.ino
 
 $ git diff --word-diff <4>
 diff --git a/blink.ino b/blink.ino

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -71,7 +71,7 @@ $ cd blink
 $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
-$ sed -i '' 's/1000/3000/' blink.ino <3>
+$ sed -i 's/1000/3000/' blink.ino <3>
 
 $ git diff --word-diff <4>
 diff --git a/blink.ino b/blink.ino

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -71,7 +71,8 @@ $ cd blink
 $ git checkout -b slow-blink <2>
 Switched to a new branch 'slow-blink'
 
-$ sed -i 's/1000/3000/' blink.ino <3>
+$ sed -i '' 's/1000/3000/' blink.ino <3> (MacOSX)
+$ sed -i 's/1000/3000/' blink.ino <3> (Linux)
 
 $ git diff --word-diff <4>
 diff --git a/blink.ino b/blink.ino


### PR DESCRIPTION
in Chapt. 6 Sect. 2, the following command seems to have a typo, causing the error below: 

>$ sed -i '' 's/1000/3000/'  blink.ino
>sed: can't read s/1000/3000/: No such file or directory
