### PR TITLE
Bazaar

### DIFF
--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -55,6 +55,7 @@ So in this case you have nothing to do.
 
 At this point, the way to import a Bazaar repository differs according to that you have a single branch or you are working with a repository that has several branches.
 
+
 ===== Project with a single branch
 
 Now `cd` in the directory that contains your Bazaar repository and initialize the Git repository:
@@ -72,48 +73,6 @@ $ bzr fast-export --plain . | git fast-import
 
 Depending on the size of the project, your Git repository is built in a lapse from a few seconds to a few minutes.
 
-At this point, the `.git` directory and your working tree are all set up, but the working tree and the index are not synchronized with HEAD:
-
-[source,console]
-----
-$ git status
-On master branch
-Changes that will be validated:
-  (use "git reset HEAD <fichier>..." to unstage)
-
-        removed :        .bzrignore
-        removed :        file.txt
-
-----
-
-This is fixed by typing:
-
-[source,console]
-----
-$ git reset --hard HEAD
-----
-
-Now let us have a look at the files to ignore.
-As `.bzrignore`'s format is completely compatible with `.gitignore`'s format, the simplest is to rename your `.bzrignore` file:
-[source,console]
-----
-$ git mv .bzrignore .gitignore
-----
-
-Then you have to create a commit that contains this change for the migration:
-[source,console]
-----
-$ git commit -am 'Migration from Bazaar to Git'
-----
-
-That's all!
-Now you can push the repository onto its new home server:
-[source,console]
-----
-$ git remote add origin git@my-git-server:mygitrepository.git
-$ git push origin --all
-$ git push origin --tags
-----
 
 ===== Case of a project with a main branch and a working branch
 
@@ -149,11 +108,38 @@ git fast-import --import-marks=../marks.git --export-marks=../marks.git
 Now `git branch` shows you the `master` branch as well as the `work` branch.
 Check the logs to make sure they’re complete and get rid of the `marks.bzr` and `marks.git` files.
 
-Your working copy is still unsynchronized, so let's reset it:
 
+===== Synchronize the staging area
+
+Whatever the number of branches you had and the import method you used, your staging area is not synchronized with HEAD, and with the import of several branches, your working directory is not synchronized neither.
+This situation is easily solved by the following command:
 [source,console]
 ----
 $ git reset --hard HEAD
+----
+
+
+===== Ignore the files that were ignored with .bzrignore
+
+Now let us have a look at the files to ignore.
+As `.bzrignore`'s format is completely compatible with `.gitignore`'s format, the simplest is to rename your `.bzrignore` file.
+You will also have to create a commit that contains this change for the migration:
+[source,console]
+----
+$ git mv .bzrignore .gitignore
+$ git commit -am 'Migration from Bazaar to Git'
+----
+
+
+===== Send your repository to the server
+
+Here we are!
+Now you can push the repository onto its new home server:
+[source,console]
+----
+$ git remote add origin git@my-git-server:mygitrepository.git
+$ git push origin --all
+$ git push origin --tags
 ----
 
 Your Git repository is ready to use.

--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -138,7 +138,7 @@ $ git mv .bzrignore .gitignore
 $ git commit -am 'Migration from Bazaar to Git'
 ----
 
-===== Send your repository to the server
+===== Sending your repository to the server
 
 Here we are!
 Now you can push the repository onto its new home server:

--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -4,31 +4,34 @@
 Bazaar is a DVCS tool much like Git, and as a result it's pretty straightforward to convert a Bazaar repository into a Git one.
 To accomplish this, you'll need to import the `bzr-fastimport` plugin.
 
-
 ===== Getting the bzr-fastimport plugin
 
 The procedure for installing the fastimport plugin is different on UNIX-like operating systems and on Windows.
 In the first case, the simplest is to install the `bzr-fastimport` package that will install all the required dependencies.
 
 For example, with Debian and derived, you would do the following:
+
 [source,console]
 ----
 $ sudo apt-get install bzr-fastimport
 ----
 
 With RHEL, you would do the following:
+
 [source,console]
 ----
 $ sudo yum install bzr-fast-import
 ----
 
 With Fedora, since release 22, the new package manager is dnf:
+
 [source,console]
 ----
 $ sudo dnf install bzr-fastimport
 ----
 
 If the package is not available, you may install it as a plugin:
+
 [source,console]
 ----
 $ mkdir --parents ~/.bazaar/plugins/bzr     # creates the necessary folders for the plugins
@@ -40,6 +43,7 @@ $ sudo python setup.py install --record=files.txt   # installs the plugin
 
 For this plugin to work, you'll also need the `fastimport` Python module.
 You can check whether it is present or not and install it with the following commands:
+
 [source,console]
 ----
 $ python -c "import fastimport"
@@ -55,10 +59,10 @@ So in this case you have nothing to do.
 
 At this point, the way to import a Bazaar repository differs according to that you have a single branch or you are working with a repository that has several branches.
 
-
 ===== Project with a single branch
 
 Now `cd` in the directory that contains your Bazaar repository and initialize the Git repository:
+
 [source,console]
 ----
 $ cd /path/to/the/bzr/repository
@@ -66,6 +70,7 @@ $ git init
 ----
 
 Now, you can simply export your Bazaar repository and convert it into a Git repository using the following command:
+
 [source,console]
 ----
 $ bzr fast-export --plain . | git fast-import
@@ -73,11 +78,11 @@ $ bzr fast-export --plain . | git fast-import
 
 Depending on the size of the project, your Git repository is built in a lapse from a few seconds to a few minutes.
 
-
 ===== Case of a project with a main branch and a working branch
 
 You can also import a Bazaar repository that contains branches.
 Let us suppose that you have two branches: one represents the main branch (myProject.trunk), the other one is the working branch (myProject.work).
+
 [source,console]
 ----
 $ ls
@@ -85,6 +90,7 @@ myProject.trunk myProject.work
 ----
 
 Create the Git repository and `cd` into it:
+
 [source,console]
 ----
 $ git init git-repo
@@ -92,6 +98,7 @@ $ cd git-repo
 ----
 
 Pull the master branch into git:
+
 [source,console]
 ----
 $ bzr fast-export --export-marks=../marks.bzr ../myProject.trunk | \
@@ -99,6 +106,7 @@ git fast-import --export-marks=../marks.git
 ----
 
 Pull the working branch into Git:
+
 [source,console]
 ----
 $ bzr fast-export --marks=../marks.bzr --git-branch=work ../myProject.work | \
@@ -108,33 +116,33 @@ git fast-import --import-marks=../marks.git --export-marks=../marks.git
 Now `git branch` shows you the `master` branch as well as the `work` branch.
 Check the logs to make sure they’re complete and get rid of the `marks.bzr` and `marks.git` files.
 
+===== Synchronizing the staging area
 
-===== Synchronize the staging area
-
-Whatever the number of branches you had and the import method you used, your staging area is not synchronized with HEAD, and with the import of several branches, your working directory is not synchronized neither.
+Whatever the number of branches you had and the import method you used, your staging area is not synchronized with `HEAD`, and with the import of several branches, your working directory is not synchronized either.
 This situation is easily solved by the following command:
+
 [source,console]
 ----
 $ git reset --hard HEAD
 ----
 
+===== Ignoring the files that were ignored with .bzrignore
 
-===== Ignore the files that were ignored with .bzrignore
-
-Now let us have a look at the files to ignore.
+Now let's have a look at the files to ignore.
 As `.bzrignore`'s format is completely compatible with `.gitignore`'s format, the simplest is to rename your `.bzrignore` file.
 You will also have to create a commit that contains this change for the migration:
+
 [source,console]
 ----
 $ git mv .bzrignore .gitignore
 $ git commit -am 'Migration from Bazaar to Git'
 ----
 
-
 ===== Send your repository to the server
 
 Here we are!
 Now you can push the repository onto its new home server:
+
 [source,console]
 ----
 $ git remote add origin git@my-git-server:mygitrepository.git


### PR DESCRIPTION
It was necessary to rewrite the section about importing a Bazaar repository into a Git repository because some operations were common regardless the user imports one or several branches.

I hope it is more clear now.