### PR TITLE
Update and simplify Apache config

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -13,10 +13,10 @@ If you don't have Apache setup, you can do so on a Linux box with something like
 [source,console]
 ----
 $ sudo apt-get install apache2 apache2-utils
-$ a2enmod cgi alias env rewrite
+$ a2enmod cgi alias env
 ----
 
-This also enables the `mod_cgi`, `mod_alias`, `mod_env`, and `mod_rewrite` modules, which are all needed for this to work properly.
+This also enables the `mod_cgi`, `mod_alias`, and `mod_env` modules, which are all needed for this to work properly.
 
 You’ll also need to set the Unix user group of the `/srv/git` directories to `www-data` so your web server can read- and write-access the repositories, because the Apache instance running the CGI script will (by default) be running as that user:
 
@@ -40,19 +40,12 @@ Finally you'll want to tell Apache to allow requests to `git-http-backend` and m
 
 [source,console]
 ----
-RewriteEngine On
-RewriteCond %{QUERY_STRING} service=git-receive-pack [OR]
-RewriteCond %{REQUEST_URI} /git-receive-pack$
-RewriteRule ^/git/ - [E=AUTHREQUIRED]
-
 <Files "git-http-backend">
     AuthType Basic
     AuthName "Git Access"
     AuthUserFile /srv/git/.htpasswd
+    Require expr !(%{QUERY_STRING} -strmatch '*service=git-receive-pack*' || %{REQUEST_URI} =~ m#/git-receive-pack$#)
     Require valid-user
-    Order deny,allow
-    Deny from env=AUTHREQUIRED
-    Satisfy any
 </Files>
 ----
 


### PR DESCRIPTION
Use `Require expr` feature of `mod_authz_core` to remove the need for mod_rewrite and simplify the entire configuration. 

This is my idea to fix issue #730. The single `Require expr ...` line replaces all of the rewrite rules and the Order/Deny/Satisfy lines.

Someone who knows more about Git than I do should probably verify that this configuration does what is needed. It seems to work for me, but I am much more knowledgeable about Apache configuration than Git's inner workings, so my testing of it may not have covered all cases.