### PR TITLE
first-time-setup.asc. Editor commands. x86 V x64 swap.

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -55,12 +55,12 @@ While on a Windows system, if you want to use a different text editor, such as N
 On a x86 system
 [source,console]
 ----
-$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
+$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
 On a x64 system
 [source,console]
 ----
-$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"
+$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
 
 [NOTE]


### PR DESCRIPTION
Swap commands for `git config --global core.editor ...` to properly
correspond to their respective introductions: "On a xYY system".

Mere errata.