### PR TITLE
Update outdated information for credential storage.

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,8 +19,8 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an ``osxkeychain'' mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, you can install a helper called ``wincred.''
-  This is similar to the ``osxkeychain'' helper described above, but uses the Windows Credential Store to control sensitive information.
+* If you're using Windows, you can install a helper called ``Git Credential Manager for Windows.''
+  This is similar to the ``osxkeychain'' helper described above, but uses the Windows Credential Store to control sensitive information. It can be found at https://github.com/Microsoft/Git-Credential-Manager-for-Windows[]. It's the successor to the ``Windows Credential Store for Git'' (``git-credential-winstore'', a.k.a. ``wincred''), which is no longer maintained.
 
 You can choose one of these methods by setting a Git configuration value:
 

--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -20,7 +20,8 @@ Git has a few options provided in the box:
 * If you're using a Mac, Git comes with an ``osxkeychain'' mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
 * If you're using Windows, you can install a helper called ``Git Credential Manager for Windows.''
-  This is similar to the ``osxkeychain'' helper described above, but uses the Windows Credential Store to control sensitive information. It can be found at https://github.com/Microsoft/Git-Credential-Manager-for-Windows[]. It's the successor to the ``Windows Credential Store for Git'' (``git-credential-winstore'', a.k.a. ``wincred''), which is no longer maintained.
+  This is similar to the ``osxkeychain'' helper described above, but uses the Windows Credential Store to control sensitive information.
+  It can be found at https://github.com/Microsoft/Git-Credential-Manager-for-Windows[].
 
 You can choose one of these methods by setting a Git configuration value:
 


### PR DESCRIPTION
Wincred is no longer maintained and has been replaced by Git Credential
Manager for Windows.