### PR TITLE
bzr-fastimport

### DIFF
--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -20,7 +20,7 @@ With RHEL, you would do the following:
 
 [source,console]
 ----
-$ sudo yum install bzr-fast-import
+$ sudo yum install bzr-fastimport
 ----
 
 With Fedora, since release 22, the new package manager is dnf:


### PR DESCRIPTION
There was an error about the package to install with RHEL to import a Bazaar repository into a Git repository.
The good one is `bzr-fastimport`.