### PR TITLE
fix #744

### DIFF
--- a/progit.asc
+++ b/progit.asc
@@ -4,6 +4,7 @@ Pro Git
 :docinfo:
 :toc:
 :toclevels: 2
+:pagenums:
 :front-cover-image: image:book/cover.png[width=1050,height=1600]
 
 include::book/preface.asc[]


### PR DESCRIPTION
add page numbers when generating pdf

there are 2 ways to add page numbers

1. add `:pagenums:` inside progit.asc
2. change Rakefile. `asciidoctor-pdf -a pagenums progit.asc`

or simply run `asciidoctor-pdf -a pagenums progit.asc 2>/dev/null` instead of  `rake book:build`

I chose the 1st, because it is more general. not sure which is better.