### PR TITLE
Minor text changes to First-time Git setup

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -71,7 +71,8 @@ If you are not familiar with these editors, you may need to search for specific 
 
 [WARNING]
 ====
-You may find, if you don't setup your editor like this, you get into a really confusing state when Git attempts to launch it. An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
+You may find, if you don't setup your editor like this, you get into a really confusing state when Git attempts to launch it.
+An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
 ==== Checking Your Settings

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -66,13 +66,12 @@ $ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.e
 [NOTE]
 ====
 Vim, Emacs and Notepad++ are popular text editors often used by developers on Unix based systems like Linux and OS X or a Windows system.
-If you are not familiar with either of these editors, you may need to search for specific instructions for how to set up your favorite editor with Git.
+If you are not familiar with these editors, you may need to search for specific instructions for how to set up your favorite editor with Git.
 ====
 
 [WARNING]
 ====
-You may find, if you don't setup an editor like this, you will likely get into a really confusing state when they are launched.
-Such example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
+You may find, if you don't setup your editor like this, you get into a really confusing state when Git attempts to launch it. An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
 ==== Checking Your Settings


### PR DESCRIPTION
- Text referred to "either" editor when several were listed
- Make the "Warning" less vague/confusing (I interpret it as being about what could happen if Git can't find an editor)