### PR TITLE
corrected the representation of the combination of keys "alt + →"

### DIFF
--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -13,7 +13,7 @@ Fortunately, this process is very well-documented and supported.
 
 There are a few methods you can pursue to install GitLab.
 To get something up and running quickly, you can download a virtual machine image or a one-click installer from https://bitnami.com/stack/gitlab[], and tweak the configuration to match your particular environment.(((bitnami)))
-One nice touch Bitnami has included is the login screen (accessed by typing alt-&rarr;); it tells you the IP address and default username and password for the installed GitLab.
+One nice touch Bitnami has included is the login screen (accessed by typing alt+→); it tells you the IP address and default username and password for the installed GitLab.
 
 [[bitnami]]
 .The Bitnami GitLab virtual machine login screen.


### PR DESCRIPTION
Hello,

I realized that there are some problems with the PDF version of progit in the section GitLab due to the xml entity representing the right arrow.
The problems were :
* the link to bitnami was not correctly formed
* in the french version, the apostrophe was replaced by "&amp;#8217;"
* the right-arrow doesn't appear as it should be.

Here are the changes I made :

* replaced the '-' delimiter by a '+'
* replaced the xml entity that represents the right arrow by the symbol of the right arrow ('→')

Adrien Ollier