### PR TITLE
Update README.asc

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -17,9 +17,8 @@ See link:CONTRIBUTING.md[the Contributing document] for more information.
 There are two ways to generate e-book content from this source code.
 
 The easiest way is simply to let us do it.
-A robot is standing by to look for new work on the main branch and automatically build it for everyone.
 
-You can find the current builds on http://git-scm.com/book[].
+You can find the current HTML version on http://git-scm.com/book[].
 
 The other way to generate e-book files is to do so manually with Asciidoctor.
 If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
@@ -38,6 +37,12 @@ Converting to PDF...
 ----
 
 This uses the `asciidoctor`, `asciidoctor-pdf` and `asciidoctor-epub` projects.
+
+Another option is to run the following:
+
+----
+asciidoctor-pdf progit.asc
+----
 
 == Signaling an Issue
 

--- a/README.asc
+++ b/README.asc
@@ -36,13 +36,14 @@ Converting to PDF...
  -- PDF  output at progit.pdf
 ----
 
-This uses the `asciidoctor`, `asciidoctor-pdf` and `asciidoctor-epub` projects.
-
-Another option is to run the following:
+You can also use the following command to generate a PDF:
 
 ----
 asciidoctor-pdf progit.asc
 ----
+
+Both use the `asciidoctor`, `asciidoctor-pdf` and `asciidoctor-epub` projects.
+
 
 == Signaling an Issue
 

--- a/README.asc
+++ b/README.asc
@@ -30,10 +30,12 @@ Converting to PDF...
  -- PDF  output at progit.pdf
 ----
 
-You can also use the following command to generate a PDF:
+You can also use the following commands:
 
 ----
-asciidoctor-pdf progit.asc
+$ asciidoctor-pdf progit.asc
+$ asciidoctor-epub3 progit.asc
+$ asciidoctor-epub3 -a ebook-format=kf8 progit.asc
 ----
 
 Both use the `asciidoctor`, `asciidoctor-pdf` and `asciidoctor-epub` projects.

--- a/README.asc
+++ b/README.asc
@@ -14,13 +14,7 @@ See link:CONTRIBUTING.md[the Contributing document] for more information.
 
 == How To Generate the Book
 
-There are two ways to generate e-book content from this source code.
-
-The easiest way is simply to let us do it.
-
-You can find the current HTML version on http://git-scm.com/book[].
-
-The other way to generate e-book files is to do so manually with Asciidoctor.
+You can generate the e-book files manually with Asciidoctor.
 If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
 
 ----


### PR DESCRIPTION
Addressing issues raised in #747 . Clarifies that the git website only hosts an HTML version and that a local build can be generated with a different `asciidoctor` command option.