### PR TITLE
SVN test repository

### DIFF
--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -28,7 +28,7 @@ If you're working with a team, and some are using SVN and others are using Git, 
 ===== Setting Up
 
 To demonstrate this functionality, you need a typical SVN repository that you have write access to.
-If you want to copy these examples, you'll have to make a writeable copy of a SVN test repository.
+If you want to copy these examples, you'll have to make a writeable copy of an SVN test repository.
 In order to do that easily, you can use a tool called `svnsync` that comes with Subversion.
 
 To follow along, you first need to create a new local Subversion repository:

--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -28,7 +28,7 @@ If you're working with a team, and some are using SVN and others are using Git, 
 ===== Setting Up
 
 To demonstrate this functionality, you need a typical SVN repository that you have write access to.
-If you want to copy these examples, you'll have to make a writeable copy of my test repository.
+If you want to copy these examples, you'll have to make a writeable copy of a SVN test repository.
 In order to do that easily, you can use a tool called `svnsync` that comes with Subversion.
 
 To follow along, you first need to create a new local Subversion repository:


### PR DESCRIPTION
The original SVN test repository is gone.
The reader have to use another SVN test repository.

Related to #631 and #653.