### PR TITLE
updated CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,6 @@ To add a figure:
 
 ## Translations
 
-Translations to other languages are highly encouraged but handled a little differently than the first edition. We now keep each translation in a separate repository and automatically build the output files through Atlas. This was something that was really difficult in the last edition.
+Translations to other languages are highly encouraged but handled a little differently than the first edition. We now keep each translation in a separate repository.
 
-Since each translation is a different repository, we can also have different maintainers for each project. The Pro Git team simply pulls them in and builds them for the translation teams. To get automatic builds, translations repositories will have to be under the [`progit` organization on GitHub](https://github.com/progit).
-
-You can find out information on all the current translations and information on how to start your own at http://progit.org/translations.
+Since each translation is a different repository, we can also have different maintainers for each project. The Pro Git team simply pulls them in and builds them for the translation teams. Translations repositories will have to be under the [`progit` organization on GitHub](https://github.com/progit).


### PR DESCRIPTION
 - removed reference to http://progit.org
 - removed reference to automatic builds

I removed reference to [progit.org](http://progit.org) since it does not seem to become available again (issues are open about this subject).
Automatic builds are no longer available, that's why I removed this reference too, allowing to not confuse new contributors.

Adrien Ollier