### PR TITLE
Update gitweb apache example for apache2.4

### DIFF
--- a/book/04-git-server/sections/gitweb.asc
+++ b/book/04-git-server/sections/gitweb.asc
@@ -56,7 +56,7 @@ Now, you need to make Apache use CGI for that script, for which you can add a Vi
     ServerName gitserver
     DocumentRoot /var/www/gitweb
     <Directory /var/www/gitweb>
-        Options ExecCGI +FollowSymLinks +SymLinksIfOwnerMatch
+        Options +ExecCGI +FollowSymLinks +SymLinksIfOwnerMatch
         AllowOverride All
         order allow,deny
         Allow from all


### PR DESCRIPTION
In apache2.4 mixing `Options` with a `+` or a `-` with those without
will cause startup to abort. This patch updates the example gitweb
apache virtualserver to a valid configuration for apache2.4.