### PR TITLE
replaced "index" with "staging area" in section 2.2

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -521,7 +521,7 @@ Changes to be committed:
 ----
 
 The next time you commit, the file will be gone and no longer tracked.
-If you modified the file and added it to the index already, you must force the removal with the `-f` option.
+If you modified the file and added it to the staging area already, you must force the removal with the `-f` option.
 This is a safety feature to prevent accidental removal of data that hasn't yet been recorded in a snapshot and that can't be recovered from Git.
 
 Another useful thing you may want to do is to keep the file in your working tree but remove it from your staging area.


### PR DESCRIPTION
While reading this excellent book on Git,  in section 2.2 (Recording Changes...), found a slightly confusing use of the term "index" in the section on removal of files:

"The next time you commit, the file will be gone and no longer tracked. If you modified the file and added it to the index already ..."

I don't believe "index" was discussed in the prior sections, so  I replaced "index" with "staging area" which I think is what index is referring to.  This seems to read a little more consistently or clearly relative to the rest of the material.  I hope this is helpful.  Thanks.