### PR TITLE
Resolve 32/64-bit confusion for Windows editors

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -53,7 +53,7 @@ $ git config --global core.editor emacs
 On a Windows system, if you want to use a different text editor, you must specify the full path to its executable file.
 This can be different depending on how your editor is packaged.
 
-In the case of Notepad++, a popular programming editor, the application is always shipped as a 32-bit executable.
+In the case of Notepad++, a popular programming editor, you are likely to want to use the 32-bit version, since at the time of writing the 64-bit version doesn't support all plug-ins.
 If you are on a 32-bit Windows system, or you have a 64-bit editor on a 64-bit system, you'll type something like this:
 
 [source,console]

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -50,14 +50,19 @@ If you want to use a different text editor, such as Emacs, you can do the follow
 $ git config --global core.editor emacs
 ----
 
-While on a Windows system, if you want to use a different text editor, such as Notepad++, you can do the following:
+On a Windows system, if you want to use a different text editor, you must specify the full path to its executable file.
+This can be different depending on how your editor is packaged.
 
-On a x86 system
+In the case of Notepad++, a popular programming editor, the application is always shipped as a 32-bit executable.
+If you are on a 32-bit Windows system, or you have a 64-bit editor on a 64-bit system, you'll type something like this:
+
 [source,console]
 ----
 $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
-On a x64 system
+
+If you have a 32-bit editor on a 64-bit system, the program will be installed in `C:\Program Files (x86)`:
+
 [source,console]
 ----
 $ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"


### PR DESCRIPTION
This aims to address the confusion that leads to pull requests like #733, #732, #707, #671, and probably others. It aims to be more explicit with the`core.editor` instructions when it comes to 32-bit editors on a 64-bit system.