### PR TITLE
Minor cleanup in 10.2 regarding new tree creation and in 5.2 to explain format of return message from push.

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -143,7 +143,9 @@ To jessica@githost:simplegit.git
    1edee6b..fbff5bc  master -> master
 ----
 
-John tries to push his change up, too:
+The last line of the output above shows a useful return message from the push operation.  The basic format is `<oldref>..<newref> fromref -> toref`, where oldref means the old reference, newref means the new reference, fromref is the name of the local reference being pushed, and toref is the name of the remote reference being updated.  You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.  More details are available in the documentation for git push.
+
+Continuing with the example, John tries to push his change up, too:
 
 [source,console]
 ----

--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -143,7 +143,10 @@ To jessica@githost:simplegit.git
    1edee6b..fbff5bc  master -> master
 ----
 
-The last line of the output above shows a useful return message from the push operation.  The basic format is `<oldref>..<newref> fromref \-> toref`, where `oldref` means the old reference, `newref` means the new reference, `fromref` is the name of the local reference being pushed, and `toref` is the name of the remote reference being updated.  You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.  More details are available in the documentation for git push.
+The last line of the output above shows a useful return message from the push operation.
+The basic format is `<oldref>..<newref> fromref \-> toref`, where `oldref` means the old reference, `newref` means the new reference, `fromref` is the name of the local reference being pushed, and `toref` is the name of the remote reference being updated.
+You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.
+More details are available in the documentation for https://git-scm.com/docs/git-push[git push].
 
 Continuing with the example, John tries to push his change up, too:
 

--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -143,7 +143,7 @@ To jessica@githost:simplegit.git
    1edee6b..fbff5bc  master -> master
 ----
 
-The last line of the output above shows a useful return message from the push operation.  The basic format is `<oldref>..<newref> fromref -> toref`, where oldref means the old reference, newref means the new reference, fromref is the name of the local reference being pushed, and toref is the name of the remote reference being updated.  You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.  More details are available in the documentation for git push.
+The last line of the output above shows a useful return message from the push operation.  The basic format is `<oldref>..<newref> fromref \-> toref`, where `oldref` means the old reference, `newref` means the new reference, `fromref` is the name of the local reference being pushed, and `toref` is the name of the remote reference being updated.  You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.  More details are available in the documentation for git push.
 
 Continuing with the example, John tries to push his change up, too:
 

--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -146,7 +146,7 @@ To jessica@githost:simplegit.git
 The last line of the output above shows a useful return message from the push operation.
 The basic format is `<oldref>..<newref> fromref \-> toref`, where `oldref` means the old reference, `newref` means the new reference, `fromref` is the name of the local reference being pushed, and `toref` is the name of the remote reference being updated.
 You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.
-More details are available in the documentation for https://git-scm.com/docs/git-push[git push].
+More details are available in the documentation for https://git-scm.com/docs/git-push[git-push].
 
 Continuing with the example, John tries to push his change up, too:
 

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -188,9 +188,8 @@ You'll now create a new tree with the second version of `test.txt` and a new fil
 [source,console]
 ----
 $ echo 'new file' > new.txt
-$ git update-index --cacheinfo 100644 \
+$ git update-index --add --cacheinfo 100644 \
   1f7a7a472abf3dd9643fd615f6da379c4acb3e3a test.txt
-$ git update-index test.txt
 $ git update-index --add new.txt
 ----
 


### PR DESCRIPTION
As I was reading section 10.2 regarding git internals and tree creation, I found what I think might be a minor omission of an "--add" flag and a superfluous "update-index" statement.  I provide what I believe is a more streamlined and corrected version in this PR.  Thanks.