### PR TITLE
Correct documentation for GIT_WORK_TREE based on git-config(1)

### DIFF
--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -38,8 +38,7 @@ If this isn't specified, Git walks up the directory tree until it gets to `~` or
 *`GIT_CEILING_DIRECTORIES`* controls the behavior of searching for a `.git` directory.
 If you access directories that are slow to load (such as those on a tape drive, or across a slow network connection), you may want to have Git stop trying earlier than it might otherwise, especially if Git is invoked when building your shell prompt.
 
-*`GIT_WORK_TREE`* is the location of the root of the working directory for a non-bare repository.
-If not specified, the parent directory of `$GIT_DIR` is used.
+*`GIT_WORK_TREE`* is the location of the root of the working directory for a non-bare repository. If --git-dir or GIT_DIR is specified but none of --work-tree, GIT_WORK_TREE and core.worktree is specified, the current working directory is regarded as the top level of your working tree.
 
 *`GIT_INDEX_FILE`* is the path to the index file (non-bare repositories only).
 


### PR DESCRIPTION
The documentation for GIT_WORK_TREE incorrectly states that it will default to the parent directory of GIT_DIR. This contradicts the actual behavior and documentation of `core.worktree` in git-config(1): https://git-scm.com/docs/git-config#git-config-coreworktree

Do you think the same warning should be included in the documentation for `GIT_DIR`? I found this to be kind of a footgun when using `GIT_DIR`.