### PR TITLE
Correct section on checking out tags

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -211,13 +211,25 @@ Now, when someone else clones or pulls from your repository, they will get all y
 
 ==== Checking out Tags
 
-You can't really check out a tag in Git, since they can't be moved around.
-If you want to put a version of your repository in your working directory that looks like a specific tag, you can create a new branch at a specific tag with  `git checkout -b [branchname] [tagname]`:
+You can check out a tag through the `git checkout` command the same way you would with a commit:
 
 [source,console]
 ----
-$ git checkout -b version2 v2.0.0
-Switched to a new branch 'version2'
-----
+$ git checkout 2.0.0
+Note: checking out '2.0.0'.
 
-Of course if you do this and do a commit, your `version2` branch will be slightly different than your `v2.0.0` tag since it will move forward with your new changes, so do be careful.
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at 99ada87... Merge pull request #89 from schacon/appendix-final
+
+$ git checkout 2.0-beta-0.1
+Previous HEAD position was 99ada87... Merge pull request #89 from schacon/appendix-final
+HEAD is now at df3f601... add atlas.json and cover image
+----

--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -211,7 +211,7 @@ Now, when someone else clones or pulls from your repository, they will get all y
 
 ==== Checking out Tags
 
-You can check out a tag through the `git checkout` command the same way you would with a commit:
+If you want to view the versions of files a tag is pointing to, you can do a git checkout, though this puts your repository in ``detached HEAD'' state, which has some ill side effects:
 
 [source,console]
 ----
@@ -233,3 +233,13 @@ $ git checkout 2.0-beta-0.1
 Previous HEAD position was 99ada87... Merge pull request #89 from schacon/appendix-final
 HEAD is now at df3f601... add atlas.json and cover image
 ----
+
+In ``detached HEAD'' state, if you make changes and then create a commit, the tag will stay the same, but your new commit won't belong to any branch and will be unreachable, except for by the exact commit hash. Thus, if you need to make changes—say you're fixing a bug on an older version, for instance—you will generally want to create a branch:
+
+[source,console]
+----
+$ git checkout -b version2 v2.0.0
+Switched to a new branch 'version2'
+----
+
+If you do this and make a commit, your `version2` branch will be slightly different than your `v2.0.0` tag since it will move forward with your new changes, so do be careful.


### PR DESCRIPTION
This commit updates the section on checking out tags by replacing
the old text saying you can't really do it with a short paragraph
explaining how to do it.

---

Just a small tweak I found when reading up on tagging today. This removes the explanatory text after the command example too, which has not been replaced (partially because I wasn't sure exactly what to put there, and partially because it no longer seems as relevant, as it works the same way as when checking out commits), though I would be happy to do so if it is deemed necessary.

Fixes #784.