### PR TITLE
There is no such problem in Git version 2.10.1

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -874,33 +874,6 @@ Unpacking objects: 100% (11/11), done.
 Checking connectivity... done.
 ----
 
-Now suppose you did that in a branch.
-If you try to switch back to a branch where those files are still in the actual tree rather than a submodule – you get this error:
-
-[source,console]
-----
-$ git checkout master
-error: The following untracked working tree files would be overwritten by checkout:
-  CryptoLibrary/Makefile
-  CryptoLibrary/includes/crypto.h
-  ...
-Please move or remove them before you can switch branches.
-Aborting
-----
-
-You can force it to switch with `checkout -f`, but be careful that you don't have unsaved changes in there as they could be overwritten with that command.
-
-[source,console]
-----
-$ git checkout -f master
-warning: unable to rmdir CryptoLibrary: Directory not empty
-Switched to branch 'master'
-----
-
-Then, when you switch back, you get an empty `CryptoLibrary` directory for some reason and `git submodule update` may not fix it either.
-You may need to go into your submodule directory and run a `git checkout .` to get all your files back.
-You could run this in a `submodule foreach` script to run it for multiple submodules.
-
 It's important to note that submodules these days keep all their Git data in the top project's `.git` directory, so unlike much older versions of Git, destroying a submodule directory won't lose any commits or branches that you had.
 
 With these tools, submodules can be a fairly simple and effective method for developing on several related but still separate projects simultaneously.


### PR DESCRIPTION
Git version 2.10.1 
```
Now suppose you did that in a branch. If you try to switch back to a branch where those files are still in the actual tree rather than a submodule – you get this error:

$ git checkout master
error: The following untracked working tree files would be overwritten by checkout:
  CryptoLibrary/Makefile
  CryptoLibrary/includes/crypto.h
  ...
Please move or remove them before you can switch branches.
Aborting
You can force it to switch with checkout -f, but be careful that you don’t have unsaved changes in there as they could be overwritten with that command.

$ git checkout -f master
warning: unable to rmdir CryptoLibrary: Directory not empty
Switched to branch 'master'
Then, when you switch back, you get an empty CryptoLibrary directory for some reason and git submodule update may not fix it either. You may need to go into your submodule directory and run a git checkout . to get all your files back. You could run this in a submodule foreach script to run it for multiple submodules.
```
 Did some tests and found that did not appear.

Are i wrong?