### PR TITLE
Use square brackets for checkout [commit] [file]

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -308,8 +308,8 @@ Pay especial attention to the 'WD Safe?' column – if it says *NO*, take a seco
 | `reset --soft [commit]` | REF | NO | NO | YES
 | `reset [commit]` | REF | YES | NO | YES
 | `reset --hard [commit]` | REF | YES | YES | *NO*
-| `checkout [commit]` | HEAD | YES | YES | YES
+| `checkout <commit>` | HEAD | YES | YES | YES
 | *File Level* | | | |
-| `reset (commit) [file]` | NO | YES | NO | YES
-| `checkout [commit] [file]` | NO | YES | YES | *NO*
+| `reset [commit] <file>` | NO | YES | NO | YES
+| `checkout [commit] <file>` | NO | YES | YES | *NO*
 |================================

--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -311,5 +311,5 @@ Pay especial attention to the 'WD Safe?' column – if it says *NO*, take a seco
 | `checkout [commit]` | HEAD | YES | YES | YES
 | *File Level* | | | |
 | `reset (commit) [file]` | NO | YES | NO | YES
-| `checkout (commit) [file]` | NO | YES | YES | *NO*
+| `checkout [commit] [file]` | NO | YES | YES | *NO*
 |================================


### PR DESCRIPTION
git checkout can be used to reset a file in the work tree to the current HEAD without specifying any further, so the commit parameter is optional.