### PR TITLE
Change figure 101 caption

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -283,7 +283,7 @@ Notice that the full GitHub URL we put in there was shortened to just the inform
 Now if Tony goes back and closes out the original Pull Request, we can see that by mentioning it in the new one, GitHub has automatically created a trackback event in the Pull Request timeline. This means that anyone who visits this Pull Request and sees that it is closed can easily link back to the one that superseded it. The link will look something like <<_pr_closed>>.
 
 [[_pr_closed]]
-.Cross references rendered in a Pull Request.
+.Link back to the new Pull Request in the closed Pull Request timeline.
 image::images/mentions-03-closed.png[PR closed]
 
 In addition to issue numbers, you can also reference a specific commit by SHA-1. You have to specify a full 40 character SHA-1, but if GitHub sees that in a comment, it will link directly to the commit. Again, you can reference commits in forks or other repositories in the same way you did with issues.


### PR DESCRIPTION
The caption of Figure 100 and Figure 101 is the same. I changed the 101 to "Link back to the new Pull Request in the closed Pull Request timeline" that I think is more related to the context.