### PR TITLE
Various grammar/font/clarification fixes to Chapter 2.

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -58,17 +58,17 @@ This is an important distinction – instead of getting just a working copy, Git
 Every version of every file for the history of the project is pulled down by default when you run `git clone`.
 In fact, if your server disk gets corrupted, you can often use nearly any of the clones on any client to set the server back to the state it was in when it was cloned (you may lose some server-side hooks and such, but all the versioned data would be there – see <<_git_on_the_server>> for more details).
 
-You clone a repository with `git clone [url]`.(((git commands, clone)))
-For example, if you want to clone the Git linkable library called libgit2, you can do so like this:
+You clone a repository with `git clone <url>`.(((git commands, clone)))
+For example, if you want to clone the Git linkable library called `libgit2`, you can do so like this:
 
 [source,console]
 ----
 $ git clone https://github.com/libgit2/libgit2
 ----
 
-That creates a directory named ``libgit2'', initializes a `.git` directory inside it, pulls down all the data for that repository, and checks out a working copy of the latest version.
+That creates a directory named `libgit2`, initializes a `.git` directory inside it, pulls down all the data for that repository, and checks out a working copy of the latest version.
 If you go into the new `libgit2` directory, you'll see the project files in there, ready to be worked on or used.
-If you want to clone the repository into a directory named something other than ``libgit2'', you can specify that as the next command-line option:
+If you want to clone the repository into a directory named something other than `libgit2`, you can specify that as the next command-line option:
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -34,7 +34,7 @@ Finally, the command tells you which branch you're on and informs you that it ha
 For now, that branch is always ``master'', which is the default; you won't worry about it here.
 <<_git_branching>> will go over branches and references in detail.
 
-Let's say you add a new file to your project, a simple README file.
+Let's say you add a new file to your project, a simple `README` file.
 If the file didn't exist before, and you run `git status`, you see your untracked file like so:
 
 [source,console]
@@ -51,23 +51,23 @@ Untracked files:
 nothing added to commit but untracked files present (use "git add" to track)
 ----
 
-You can see that your new README file is untracked, because it's under the ``Untracked files'' heading in your status output.
+You can see that your new `README` file is untracked, because it's under the ``Untracked files'' heading in your status output.
 Untracked basically means that Git sees a file you didn't have in the previous snapshot (commit); Git won't start including it in your commit snapshots until you explicitly tell it to do so.
 It does this so you don't accidentally begin including generated binary files or other files that you did not mean to include.
-You do want to start including README, so let's start tracking the file.
+You do want to start including `README`, so let's start tracking the file.
 
 [[_tracking_files]]
 ==== Tracking New Files
 
 In order to begin tracking a new file, you use the command `git add`.(((git commands, add)))
-To begin tracking the README file, you can run this:
+To begin tracking the `README` file, you can run this:
 
 [source,console]
 ----
 $ git add README
 ----
 
-If you run your status command again, you can see that your README file is now tracked and staged to be committed:
+If you run your status command again, you can see that your `README` file is now tracked and staged to be committed:
 
 [source,console]
 ----
@@ -83,7 +83,7 @@ Changes to be committed:
 
 You can tell that it's staged because it's under the ``Changes to be committed'' heading.
 If you commit at this point, the version of the file at the time you ran `git add` is what will be in the historical snapshot.
-You may recall that when you ran `git init` earlier, you then ran `git add (files)` – that was to begin tracking files in your directory.(((git commands, init)))(((git commands, add)))
+You may recall that when you ran `git init` earlier, you then ran `git add <files>` – that was to begin tracking files in your directory.(((git commands, init)))(((git commands, add)))
 The `git add` command takes a path name for either a file or a directory; if it's a directory, the command adds all the files in that directory recursively.
 
 ==== Staging Modified Files
@@ -227,7 +227,7 @@ Glob patterns are like simplified regular expressions that shells use.
 An asterisk (`*`) matches zero or more characters; `[abc]` matches any character inside the brackets (in this case a, b, or c); a question mark (`?`) matches a single character; and brackets enclosing characters separated by a hyphen (`[0-9]`) matches any character between them (in this case 0 through 9).
 You can also use two asterisks to match nested directories; `a/**/z` would match `a/z`, `a/b/z`, `a/b/c/z`, and so on.
 
-Here is another example .gitignore file:
+Here is another example `.gitignore` file:
 
 [source]
 ----
@@ -408,7 +408,7 @@ $ git commit
 ----
 
 Doing so launches your editor of choice.
-(This is set by your shell's `$EDITOR` environment variable – usually vim or emacs, although you can configure it with whatever you want using the `git config --global core.editor` command as you saw in <<_getting_started>>).(((editor, changing default)))(((git commands, config)))
+(This is set by your shell's `EDITOR` environment variable – usually vim or emacs, although you can configure it with whatever you want using the `git config --global core.editor` command as you saw in <<_getting_started>>).(((editor, changing default)))(((git commands, config)))
 
 The editor displays the following text (this example is a Vim screen):
 

--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -12,7 +12,7 @@ In this section, we'll cover some of these remote-management skills.
 
 To see which remote servers you have configured, you can run the `git remote` command.(((git commands, remote)))
 It lists the shortnames of each remote handle you've specified.
-If you've cloned your repository, you should at least see origin – that is the default name Git gives to the server you cloned from:
+If you've cloned your repository, you should at least see `origin` – that is the default name Git gives to the server you cloned from:
 
 [source,console]
 ----
@@ -63,7 +63,7 @@ Notice that these remotes use a variety of protocols; we'll cover more about thi
 
 ==== Adding Remote Repositories
 
-We've mentioned and given some demonstrations of how the 'clone' command implicitly adds the `origin` remote for you.
+We've mentioned and given some demonstrations of how the `git clone` command implicitly adds the `origin` remote for you.
 Here's how to add a new remote explicitly.(((git commands, remote)))
 To add a new remote Git repository as a shortname you can reference easily, run `git remote add <shortname> <url>`:
 
@@ -104,7 +104,7 @@ As you just saw, to get data from your remote projects, you can run:(((git comma
 
 [source,console]
 ----
-$ git fetch [remote-name]
+$ git fetch <remote-name>
 ----
 
 The command goes out to that remote project and pulls down all the data from that remote project that you don't have yet.
@@ -123,7 +123,7 @@ Running `git pull` generally fetches data from the server you originally cloned 
 ==== Pushing to Your Remotes
 
 When you have your project at a point that you want to share, you have to push it upstream.
-The command for this is simple: `git push [remote-name] [branch-name]`.(((git commands, push)))
+The command for this is simple: `git push <remote-name> <branch-name>`.(((git commands, push)))
 If you want to push your master branch to your `origin` server (again, cloning generally sets up both of those names for you automatically), then you can run this to push any commits you've done back up to the server:
 
 [source,console]
@@ -139,7 +139,7 @@ See <<_git_branching>> for more detailed information on how to push to remote se
 [[_inspecting_remote]]
 ==== Inspecting a Remote
 
-If you want to see more information about a particular remote, you can use the `git remote show [remote-name]` command.(((git commands, remote)))
+If you want to see more information about a particular remote, you can use the `git remote show <remote-name>` command.(((git commands, remote)))
 If you run this command with a particular shortname, such as `origin`, you get something like this:
 
 [source,console]

--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -179,7 +179,7 @@ Date:   Sun Apr 27 20:43:35 2008 -0700
 
 By default, the `git push` command doesn't transfer tags to remote servers.(((git commands, push)))
 You will have to explicitly push tags to a shared server after you have created them.
-This process is just like sharing remote branches – you can run `git push origin [tagname]`.
+This process is just like sharing remote branches – you can run `git push origin <tagname>`.
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -7,8 +7,7 @@ Be careful, because you can't always undo some of these undos.
 This is one of the few areas in Git where you may lose some work if you do it wrong.
 
 One of the common undos takes place when you commit too early and possibly forget to add some files, or you mess up your commit message.
-If you want to redo that commit, make the additional changes you forgot, stage them, and commit
-again using the `--amend` option:
+If you want to redo that commit, make the additional changes you forgot, stage them, and commit again using the `--amend` option:
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -7,7 +7,8 @@ Be careful, because you can't always undo some of these undos.
 This is one of the few areas in Git where you may lose some work if you do it wrong.
 
 One of the common undos takes place when you commit too early and possibly forget to add some files, or you mess up your commit message.
-If you want to try that commit again, you can run commit with the `--amend` option:
+If you want to redo that commit, make the additional changes you forgot, stage them, and commit
+again using the `--amend` option:
 
 [source,console]
 ----

--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -252,8 +252,7 @@ of the `--grep` patterns; however, adding the `--all-match` option further limit
 just those commits that match _all_ `--grep` patterns.
 ====
 
-Another really helpful filter is the `-S` option (colloquially referred to as Git's ``pickaxe'' option)
-which takes a string and shows only those commits that changed the number of occurrences of that string.
+Another really helpful filter is the `-S` option (colloquially referred to as Git's ``pickaxe'' option), which takes a string and shows only those commits that changed the number of occurrences of that string.
 For instance, if you wanted to find the last commit that added or removed a reference to a specific function, you could call:
 
 [source,console]

--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -87,7 +87,6 @@ index a0a60ae..47c6340 100644
 -  git = SimpleGit.new
 -  puts git.show
 -end
-\ No newline at end of file
 ----
 
 This option displays the same information but with a diff directly following each entry.
@@ -222,6 +221,7 @@ Those are only some simple output-formatting options to `git log` – there are 
 | `--relative-date` | Display the date in a relative format (for example, ``2 weeks ago'') instead of using the full date format.
 | `--graph`         | Display an ASCII graph of the branch and merge history beside the log output.
 | `--pretty`        | Show commits in an alternate format. Options include oneline, short, full, fuller, and format (where you specify your own format).
+| `--oneline`       | Shorthand for `--pretty=oneline --abbrev-commit` used together.
 |================================
 
 ==== Limiting Log Output
@@ -243,9 +243,17 @@ This command works with lots of formats – you can specify a specific date like
 
 You can also filter the list to commits that match some search criteria.
 The `--author` option allows you to filter on a specific author, and the `--grep` option lets you search for keywords in the commit messages.
-(Note that if you want to specify both author and grep options, you have to add `--all-match` or the command will match commits with either.)
 
-Another really helpful filter is the `-S` option which takes a string and only shows the commits that introduced a change to the code that added or removed that string.
+[NOTE]
+====
+You can specify more than one instance of both the `--author` and `--grep` search criteria, which
+will limit the commit output to commits that match _any_ of the `--author` patterns and _any_
+of the `--grep` patterns; however, adding the `--all-match` option further limits the output to
+just those commits that match _all_ `--grep` patterns.
+====
+
+Another really helpful filter is the `-S` option (colloquially referred to as Git's ``pickaxe'' option)
+which takes a string and shows only those commits that changed the number of occurrences of that string.
 For instance, if you wanted to find the last commit that added or removed a reference to a specific function, you could call:
 
 [source,console]
@@ -264,7 +272,7 @@ In <<limit_options>> we'll list these and a few other common options for your re
 [cols="2,4",options="header"]
 |================================
 | Option                | Description
-| `-(n)`                | Show only the last n commits
+| `-<n>`                | Show only the last n commits
 | `--since`, `--after`  | Limit the commits to those made after the specified date.
 | `--until`, `--before` | Limit the commits to those made before the specified date.
 | `--author`            | Only show commits in which the author entry matches the specified string.


### PR DESCRIPTION
Tweaks include:

 - adjust some filenames/commands to use monospaced font
 - standardize on <> for replaceables, [] for optionals
 - Remove '$' in front of shell variables when only discussing them
 - Add "--oneline" option to log option table, given its popularity
 - Add NOTE clarifying "--all-match" option to git log
 - Minor rewording in a couple places for clarity