### PR TITLE
Add a short note mentioning there could be multiple .gitignore files.

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -257,8 +257,10 @@ GitHub maintains a fairly comprehensive list of good `.gitignore` file examples 
 
 [NOTE]
 ====
-While, in the simple case, a repository might have a single `.gitignore` file in its root directory that applies recursively to the entire repository, it is also possible to have additional `.gitignore` files sprinkled throughout a repository, with lower-level `.gitignore` files applying to just those files to be ignored in specific subdirectories in the repository.
-(The Linus kernel source repository has 206 `.gitignore` files, each of which represents files to be ignored in different parts of the directory structure.)
+In the simple case, a repository might have a single `.gitignore` file in its root directory, which applies recursively to the entire repository.
+However, it is also possible to have additional `.gitignore` files in subdirectories.
+The rules in these nested `.gitignore` files apply only to the files under the directory where they are located.
+(The Linux kernel source repository has 206 `.gitignore` files.)
 
 It is beyond the scope of this book to get into the details of multiple `.gitignore` files; see `man gitignore` for the details.
 ====

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -255,6 +255,14 @@ doc/**/*.pdf
 GitHub maintains a fairly comprehensive list of good `.gitignore` file examples for dozens of projects and languages at https://github.com/github/gitignore[] if you want a starting point for your project.
 ====
 
+[NOTE]
+====
+While, in the simple case, a repository might have a single `.gitignore` file in its root directory that applies recursively to the entire repository, it is also possible to have additional `.gitignore` files sprinkled throughout a repository, with lower-level `.gitignore` files applying to just those files to be ignored in specific subdirectories in the repository.
+(The Linus kernel source repository has 206 `.gitignore` files, each of which represents files to be ignored in different parts of the directory structure.)
+
+It is beyond the scope of this book to get into the details of multiple `.gitignore` files; see `man gitignore` for the details.
+====
+
 [[_git_diff_staged]]
 ==== Viewing Your Staged and Unstaged Changes
 


### PR DESCRIPTION
Warn the reader briefly about the possibility of multiple .gitignore files
in a single repository, and refer them to "man gitignore" for more details.