### PR TITLE
Minor grammar/clarification tweaks to Chapter 7, "Rewriting History"

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -8,6 +8,13 @@ This can involve changing the order of the commits, changing messages or modifyi
 
 In this section, you’ll cover how to accomplish these very useful tasks so that you can make your commit history look the way you want before you share it with others.
 
+[NOTE]
+====
+The cardinal rule with Git is that, since so much work is local within your clone, you have a great deal of freedom to rewrite your history _locally_.
+However, once you push your work, it is a different story entirely, and you should consider pushed work as final.
+In short, you should never push your work until you're happy with it and ready to share it with the rest of the world.
+====
+
 [[_git_amend]]
 ==== Changing the Last Commit
 
@@ -25,7 +32,7 @@ That drops you into your text editor, which has your last commit message in it, 
 When you save and close the editor, the editor writes a new commit containing that message and makes it your new last commit.
 
 If you’ve committed and then you want to change the snapshot you committed by adding or changing files, possibly because you forgot to add a newly created file when you originally committed, the process works basically the same way.
-You stage the changes you want by editing a file and running `git add` on it or `git rm` to a tracked file, and the subsequent `git commit --amend` takes your current staging area and adds it to the last snapshot making it the snapshot of the last commit.
+Make the changes you think you forgot, stage those changes, and the subsequent `git commit --amend` _replaces_ the previous commit with your new, improved commit.
 
 You need to be careful with this technique because amending changes the SHA-1 of the commit.
 It’s like a very small rebase – don’t amend your last commit if you’ve already pushed it.
@@ -40,7 +47,7 @@ You can run rebase interactively by adding the `-i` option to `git rebase`.
 You must indicate how far back you want to rewrite commits by telling the command which commit to rebase onto.
 
 For example, if you want to change the last three commit messages, or any of the commit messages in that group, you supply as an argument to `git rebase -i` the parent of the last commit you want to edit, which is `HEAD~2^` or `HEAD~3`.
-It may be easier to remember the `~3` because you’re trying to edit the last three commits; but keep in mind that you’re actually designating four commits ago, the parent of the last commit you want to edit:
+It may be easier to remember the `~3` because you’re trying to edit the last three commits, but keep in mind that you’re actually designating four commits ago, the parent of the last commit you want to edit:
 
 [source,console]
 ----
@@ -284,7 +291,7 @@ Ref 'refs/heads/master' was rewritten
 
 The `--tree-filter` option runs the specified command after each checkout of the project and then recommits the results.
 In this case, you remove a file called `passwords.txt` from every snapshot, whether it exists or not.
-If you want to remove all accidentally committed editor backup files, you can run something like `git filter-branch --tree-filter 'rm -f *~' HEAD`.
+If you want to remove all accidentally committed editor backup files, you can run something like `git filter-branch --tree-filter 'rm -rf *~' HEAD`.
 
 You’ll be able to watch Git rewriting trees and commits and then move the branch pointer at the end.
 It’s generally a good idea to do this in a testing branch and then hard-reset your master branch after you’ve determined the outcome is what you really want.

--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -10,9 +10,9 @@ In this section, you’ll cover how to accomplish these very useful tasks so tha
 
 [NOTE]
 ====
-The cardinal rule with Git is that, since so much work is local within your clone, you have a great deal of freedom to rewrite your history _locally_.
-However, once you push your work, it is a different story entirely, and you should consider pushed work as final.
-In short, you should never push your work until you're happy with it and ready to share it with the rest of the world.
+One of the cardinal rules of Git is that, since so much work is local within your clone, you have a great deal of freedom to rewrite your history _locally_.
+However, once you push your work, it is a different story entirely, and you should consider pushed work as final unless you have good reason to change it.
+In short, you should avoid pushing your work until you're happy with it and ready to share it with the rest of the world.
 ====
 
 [[_git_amend]]
@@ -291,7 +291,7 @@ Ref 'refs/heads/master' was rewritten
 
 The `--tree-filter` option runs the specified command after each checkout of the project and then recommits the results.
 In this case, you remove a file called `passwords.txt` from every snapshot, whether it exists or not.
-If you want to remove all accidentally committed editor backup files, you can run something like `git filter-branch --tree-filter 'rm -rf *~' HEAD`.
+If you want to remove all accidentally committed editor backup files, you can run something like `git filter-branch --tree-filter 'rm -f *~' HEAD`.
 
 You’ll be able to watch Git rewriting trees and commits and then move the branch pointer at the end.
 It’s generally a good idea to do this in a testing branch and then hard-reset your master branch after you’ve determined the outcome is what you really want.


### PR DESCRIPTION
Changes include:

 - Adding NOTE to emphasize rewriting history should be local.
 - Add recursive option to example about removing editor backup files.