### PR TITLE
Rename "Binary Search" section to "Bisection" section.

### DIFF
--- a/book/07-git-tools/sections/debugging.asc
+++ b/book/07-git-tools/sections/debugging.asc
@@ -63,8 +63,8 @@ This is really useful.
 Normally, you get as the original commit the commit where you copied the code over, because that is the first time you touched those lines in this file.
 Git tells you the original commit where you wrote those lines, even if it was in another file.
 
-[[_binary_search]]
-==== Binary Search
+[[_bisection]]
+==== Bisection
 
 Annotating a file helps if you know where the issue is to begin with.
 If you don’t know what is breaking, and there have been dozens or hundreds of commits since the last state where you know the code worked, you’ll likely turn to `git bisect` for help.

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -380,7 +380,7 @@ This ranges from figuring out where something was introduced to figuring out who
 
 The `git bisect` tool is an incredibly helpful debugging tool used to find which specific commit was the first one to introduce a bug or problem by doing an automatic binary search.
 
-It is fully covered in <<_binary_search>> and is only mentioned in that section.
+It is fully covered in <<_bisection>> and is only mentioned in that section.
 
 ==== git blame
 


### PR DESCRIPTION
While, yes, bisection uses binary search, it's more appropriate to
refer to it officially as bisection.