### PR TITLE
Replace backquotes, since they can't be used in the middle of a strin…

### DIFF
--- a/book/07-git-tools/sections/replace.asc
+++ b/book/07-git-tools/sections/replace.asc
@@ -1,13 +1,13 @@
 [[_replace]]
 === Replace
 
-Git's objects are unchangeable, but it does provide an interesting way to pretend to replace objects in its database with other objects.
+As we've emphasized before, the objects in Git's object database are unchangeable, but Git does provide an interesting way to _pretend_ to replace objects in its database with other objects.
 
-The `replace` command lets you specify an object in Git and say "every time you see this, pretend it's this other thing".
-This is most commonly useful for replacing one commit in your history with another one.
+The `replace` command lets you specify an object in Git and say "every time you refer to _this_ object, pretend it's a _different_ object".
+This is most commonly useful for replacing one commit in your history with another one without having to rebuild the entire history with, say, `git filter-branch`.
 
 For example, let's say you have a huge code history and want to split your repository into one short history for new developers and one much longer and larger history for people interested in data mining.
-You can graft one history onto the other by `replace`ing the earliest commit in the new line with the latest commit on the older one.
+You can graft one history onto the other by "replacing" the earliest commit in the new line with the latest commit on the older one.
 This is nice because it means that you don't actually have to rewrite every commit in the new history, as you would normally have to do to join them together (because the parentage affects the SHA-1s).
 
 Let's try this out.


### PR DESCRIPTION
…g, some rewording.

First, replace backquotes that can't be used in the middle of a string, since
they will just be rendered as is -- that is, they will show up literally as
backquotes.

Also, reword opening paragraphs for clarity.