### PR TITLE
Grammar/font/rewording tweaks to the first part of "Git Internals" ch…

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -6,7 +6,8 @@ Great.
 What does that mean?
 It means that at the core of Git is a simple key-value data store.
 You can insert any kind of content into it, and it will give you back a key that you can use to retrieve the content again at any time.
-To demonstrate, you can use the plumbing command `hash-object`, which takes some data, stores it in your `.git` directory, and gives you back the key the data is stored as.
+To demonstrate, you can use the plumbing command `hash-object`, which takes some data, stores it in your `.git/objects` directory (the _object database_), and gives you back the key the data is stored as.
+
 First, you initialize a new Git repository and verify that there is nothing in the `objects` directory:
 
 [source,console]
@@ -106,7 +107,7 @@ version 2
 ----
 
 But remembering the SHA-1 key for each version of your file isn't practical; plus, you aren't storing the filename in your system – just the content.
-This object type is called a blob.
+This object type is called a _blob_.
 You can have Git tell you the object type of any object in Git, given its SHA-1 key, with `cat-file -t`:
 
 [source,console]
@@ -118,7 +119,7 @@ blob
 [[_tree_objects]]
 ==== Tree Objects
 
-The next type we'll look at is the tree, which solves the problem of storing the filename and also allows you to store a group of files together.
+The next type we'll look at is the _tree_, which solves the problem of storing the filename and also allows you to store a group of files together.
 Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
 All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
 A single tree object contains one or more tree entries, each of which contains a SHA-1 pointer to a blob or subtree with its associated mode, type, and filename.

--- a/book/10-git-internals/sections/packfiles.asc
+++ b/book/10-git-internals/sections/packfiles.asc
@@ -1,6 +1,6 @@
 === Packfiles
 
-Let's go back to the objects database for your test Git repository.
+Let's go back to the object database for your test Git repository.
 At this point, you have 11 objects – 4 blobs, 3 trees, 3 commits, and 1 tag:
 
 [source,console]
@@ -36,7 +36,7 @@ $ git commit -m 'added repo.rb'
  rewrite test.txt (100%)
 ----
 
-If you look at the resulting tree, you can see the SHA-1 value your repo.rb file got for the blob object:
+If you look at the resulting tree, you can see the SHA-1 value your `repo.rb` file got for the blob object:
 
 [source,console]
 ----
@@ -101,7 +101,7 @@ Writing objects: 100% (18/18), done.
 Total 18 (delta 3), reused 0 (delta 0)
 ----
 
-If you look in your objects directory, you'll find that most of your objects are gone, and a new pair of files has appeared:
+If you look in your `objects` directory, you'll find that most of your objects are gone, and a new pair of files has appeared:
 
 [source,console]
 ----
@@ -119,7 +119,7 @@ Because you never added them to any commits, they're considered dangling and are
 The other files are your new packfile and an index.
 The packfile is a single file containing the contents of all the objects that were removed from your filesystem.
 The index is a file that contains offsets into that packfile so you can quickly seek to a specific object.
-What is cool is that although the objects on disk before you ran the `gc` were collectively about 15K in size, the new packfile is only 7K.
+What is cool is that although the objects on disk before you ran the `gc` command were collectively about 15K in size, the new packfile is only 7K.
 You've cut your disk usage by half by packing your objects.
 
 How does Git do this?
@@ -156,7 +156,7 @@ chain length = 1: 3 objects
 .git/objects/pack/pack-978e03944f5c581011e6998cd0e9e30000905586.pack: ok
 ----
 
-Here, the `033b4` blob, which if you remember was the first version of your repo.rb file, is referencing the `b042a` blob, which was the second version of the file.
+Here, the `033b4` blob, which if you remember was the first version of your `repo.rb` file, is referencing the `b042a` blob, which was the second version of the file.
 The third column in the output is the size of the object in the pack, so you can see that `b042a` takes up 22K of the file, but that `033b4` only takes up 9 bytes.
 What is also interesting is that the second version of the file is the one that is stored intact, whereas the original version is stored as a delta – this is because you're most likely to need faster access to the most recent version of the file.
 

--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -17,7 +17,6 @@ Here's what it looks like:
 [source,console]
 ----
 $ ls -F1
-branches/
 config
 description
 HEAD
@@ -32,7 +31,7 @@ The `description` file is used only by the GitWeb program, so don't worry about 
 The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a `.gitignore` file.
 The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<_git_hooks>>.
 
-This leaves four important entries: the `HEAD` and (yet to be created) `index` file, and the `objects` and `refs` directories.
+This leaves four important entries: the `HEAD` and (yet to be created) `index` files, and the `objects` and `refs` directories.
 These are the core parts of Git.
 The `objects` directory stores all the content for your database, the `refs` directory stores pointers into commit objects in that data (branches, tags, remotes and more), the `HEAD` file points to the branch you currently have checked out, and the `index` file is where Git stores your staging area information.
 You'll now look at each of these sections in detail to see how Git operates.

--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -2,7 +2,7 @@
 === Plumbing and Porcelain
 
 This book covers how to use Git with 30 or so verbs such as `checkout`, `branch`, `remote`, and so on.
-But because Git was initially a toolkit for a VCS rather than a full user-friendly VCS, it has a bunch of verbs that do low-level work and were designed to be chained together UNIX style or called from scripts.
+But because Git was initially a toolkit for a VCS rather than a full user-friendly VCS, it has a bunch of verbs that do low-level work and were designed to be chained together UNIX-style or called from scripts.
 These commands are generally referred to as ``plumbing'' commands, and the more user-friendly commands are called ``porcelain'' commands.
 
 The book's first nine chapters deal almost exclusively with porcelain commands.
@@ -17,9 +17,10 @@ Here's what it looks like:
 [source,console]
 ----
 $ ls -F1
-HEAD
-config*
+branches/
+config
 description
+HEAD
 hooks/
 info/
 objects/
@@ -27,11 +28,11 @@ refs/
 ----
 
 You may see some other files in there, but this is a fresh `git init` repository – it's what you see by default.
-The `description` file is only used by the GitWeb program, so don't worry about it.
-The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a .gitignore file.
+The `description` file is used only by the GitWeb program, so don't worry about it.
+The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a `.gitignore` file.
 The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<_git_hooks>>.
 
-This leaves four important entries: the `HEAD` and (yet to be created) `index` files, and the `objects` and `refs` directories.
+This leaves four important entries: the `HEAD` and (yet to be created) `index` file, and the `objects` and `refs` directories.
 These are the core parts of Git.
-The `objects` directory stores all the content for your database, the `refs` directory stores pointers into commit objects in that data (branches), the `HEAD` file points to the branch you currently have checked out, and the `index` file is where Git stores your staging area information.
+The `objects` directory stores all the content for your database, the `refs` directory stores pointers into commit objects in that data (branches, tags, remotes and more), the `HEAD` file points to the branch you currently have checked out, and the `index` file is where Git stores your staging area information.
 You'll now look at each of these sections in detail to see how Git operates.

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -63,12 +63,12 @@ Now, your Git database conceptually looks something like this:
 .Git directory objects with branch head references included.
 image::images/data-model-4.png[Git directory objects with branch head references included.]
 
-When you run commands like `git branch (branchname)`, Git basically runs that `update-ref` command to add the SHA-1 of the last commit of the branch you're on into whatever new reference you want to create.
+When you run commands like `git branch <branchname>`, Git basically runs that `update-ref` command to add the SHA-1 of the last commit of the branch you're on into whatever new reference you want to create.
 
 [[_the_head]]
 ==== The HEAD
 
-The question now is, when you run `git branch (branchname)`, how does Git know the SHA-1 of the last commit?
+The question now is, when you run `git branch <branchname>`, how does Git know the SHA-1 of the last commit?
 The answer is the HEAD file.
 
 The HEAD file is a symbolic reference to the branch you're currently on.
@@ -120,7 +120,7 @@ fatal: Refusing to point HEAD outside of refs/
 ==== Tags
 
 We just finished discussing Git's three main object types, but there is a fourth.
-The tag object is very much like a commit object – it contains a tagger, a date, a message, and a pointer.
+The _tag_ object is very much like a commit object – it contains a tagger, a date, a message, and a pointer.
 The main difference is that a tag object generally points to a commit rather than a tree.
 It's like a branch reference, but it never moves – it always points to the same commit but gives it a friendlier name.
 

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -9,7 +9,7 @@ Suppose you add a remote like this:
 $ git remote add origin https://github.com/schacon/simplegit-progit
 ----
 
-It adds a section to your `.git/config` file, specifying the name of the remote (`origin`), the URL of the remote repository, and the refspec for fetching:
+Running the above adds a section to your `.git/config` file, specifying the name of the remote (`origin`), the URL of the remote repository, and the refspec for fetching:
 
 [source,ini]
 ----


### PR DESCRIPTION
…apter.

Tweaks include:

 - monospaced font for file, directory and command names
 - hyphenation
 - minor grammar rewording
 - "objects database" -> "object database"
 - adding some first-term rendering in a few places
 - update contents of freshly-created .git directory