### PR TITLE
Expand on the rationale for creating a custom commit template.

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -64,16 +64,21 @@ Now, no matter what is set as your default shell editor, Git will fire up Emacs 
 
 (((commit templates)))
 If you set this to the path of a file on your system, Git will use that file as the default initial message when you commit.
-For instance, suppose you create a template file at `~/.gitmessage.txt` that looks like this:
+The value in creating a custom commit template is that you can use it to remind yourself (or others) of the proper format and style when creating a commit message.
+
+For instance, consider a template file at `~/.gitmessage.txt` that looks like this:
 
 [source,text]
 ----
-subject line
+Subject line (try to keep under 60 characters)
 
-what happened
+Multi-line description of commit,
+feel free to be detailed.
 
-[ticket: X]
+[Ticket: X]
 ----
+
+Note how this commit template reminds the committer to keep the subject line short (for the sake of `git log --oneline` output), to add further detail under that, and to refer to an issue or bug tracker ticket number if one exists.
 
 To tell Git to use it as the default message that appears in your editor when you run `git commit`, set the `commit.template` configuration value:
 
@@ -87,11 +92,12 @@ Then, your editor will open to something like this for your placeholder commit m
 
 [source,text]
 ----
-subject line
+Subject line (try to keep under 60 characters)
 
-what happened
+Multi-line description of commit,
+feel free to be detailed.
 
-[ticket: X]
+[Ticket: X]
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master


### PR DESCRIPTION
Throw in a bit more detail into the sample commit template file.