### PR TITLE
Rename project directory to emphasize that it's not a Git repo yet

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -7,22 +7,22 @@ The second clones an existing Git repository from another server.
 
 ==== Initializing a Repository in an Existing Directory
 
-If you're starting to track an existing project in Git, you need to go to the project's directory. If you've never done this, it looks a little different depending on which system you're running:
+If you have a project that is currently not under version control and you want to start controlling it with Git, you first need to go to that project's directory. If you've never done this, it looks a little different depending on which system you're running:
 
 for Linux:
 [source,console]
 ----
-$ cd /home/user/your_repository
+$ cd /home/user/my_project
 ----
 for Mac:
 [source,console]
 ----
-$ cd /Users/user/your_repository
+$ cd /Users/user/my_project
 ----
 for Windows:
 [source,console]
 ----
-$ cd /c/user/your_repository
+$ cd /c/user/my_project
 ----
 
 and type:


### PR DESCRIPTION
Self-explanatory -- given that you haven't initialized the project
directory as a Git repo yet, it shouldn't be called a "repository".