### PR TITLE
Emphasize changing /etc/gitconfig requires admin/superuser privilege.

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -10,6 +10,7 @@ These variables can be stored in three different places:
 
 1. `/etc/gitconfig` file: Contains values applied to every user on the system and all their repositories.
   If you pass the option `--system` to `git config`, it reads and writes from this file specifically.
+  (Because this is a system configuration file, you would need administrative or superuser privilege to make changes to it.)
 2. `~/.gitconfig` or `~/.config/git/config` file: Values specific personally to you, the user.
   You can make Git read and write to this file specifically by passing the `--global` option.
 3. `config` file in the Git directory (that is, `.git/config`) of whatever repository you're currently using: Specific to that single repository.


### PR DESCRIPTION
While it might seem obvious, it doesn't hurt to state explicitly that changing
/etc/gitconfig is restricted to privileged users.