### PR TITLE
Expand the "Getting Help" section to explain manpages versus "-h".

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -1,12 +1,11 @@
 [[_git_help]]
 === Getting Help
 
-If you ever need help while using Git, there are three ways to get the manual page (manpage) help for any of the Git commands:
+If you ever need help while using Git, there are two equivalent ways to get the comprehensive manual page (manpage) help for any of the Git commands:
 
 [source,console]
 ----
 $ git help <verb>
-$ git <verb> --help
 $ man git-<verb>
 ----
 
@@ -20,3 +19,28 @@ $ git help config
 These commands are nice because you can access them anywhere, even offline.
 If the manpages and this book aren't enough and you need in-person help, you can try the `#git` or `#github` channel on the Freenode IRC server (irc.freenode.net).
 These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.(((IRC)))
+
+In addition, if you don't need the full-blown manpage help, but just need a quick refresher on the available options for a Git command, you can ask for the more concise ``help'' output with the `-h` or `--help` options, as in:
+
+[source,console]
+----
+$ git add -h
+usage: git add [<options>] [--] <pathspec>...
+
+    -n, --dry-run         dry run
+    -v, --verbose         be verbose
+
+    -i, --interactive     interactive picking
+    -p, --patch           select hunks interactively
+    -e, --edit            edit current diff and apply
+    -f, --force           allow adding otherwise ignored files
+    -u, --update          update tracked files
+    -N, --intent-to-add   record only the fact that the path will be added later
+    -A, --all             add changes from all tracked and untracked files
+    --ignore-removal      ignore paths removed in the working tree (same as --no-all)
+    --refresh             don't add, only refresh the index
+    --ignore-errors       just skip files which cannot be added because of errors
+    --ignore-missing      check if - even missing - files are ignored in dry run
+    --chmod <(+/-)x>      override the executable bit of the listed files
+----
+


### PR DESCRIPTION
Be clearer about the distinction between the manpages for a Git command,
and the much more terse "-h|--help" option.