### PR TITLE
Add a TIP explaining the log option '--no-merges'

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -295,3 +295,10 @@ b0ad11e - pull: allow "git pull origin $something:$current_branch" into an unbor
 ----
 
 Of the nearly 40,000 commits in the Git source code history, this command shows the 6 that match those criteria.
+
+[TIP]
+.Preventing the display of merge commits
+====
+Depending on the workflow used in your repository, it's possible that a sizable percentage of the commits in your log history are just merge commits, which typically aren't very informative.
+To prevent the display of merge commits cluttering up your log history, simply add the log option `--no-merges`.
+====


### PR DESCRIPTION
Given how merge commits can clutter up one's log output,
make sure readers understand the --no-merges option.