### PR TITLE
Rename "Getting Git on a Server" link to reflect the section name

### DIFF
--- a/book/04-git-server/sections/git-on-a-server.asc
+++ b/book/04-git-server/sections/git-on-a-server.asc
@@ -1,4 +1,4 @@
-[[_git_on_the_server]]
+[[_getting_git_on_a_server]]
 === Getting Git on a Server
 
 Now we'll cover setting up a Git service running these protocols on your own server.

--- a/book/04-git-server/sections/protocols.asc
+++ b/book/04-git-server/sections/protocols.asc
@@ -46,7 +46,7 @@ Then, you can push to and pull from that remote as though you were doing so over
 The pros of file-based repositories are that they're simple and they use existing file permissions and network access.
 If you already have a shared filesystem to which your whole team has access, setting up a repository is very easy.
 You stick the bare repository copy somewhere everyone has shared access to and set the read/write permissions as you would for any other shared directory.
-We'll discuss how to export a bare repository copy for this purpose in <<_git_on_the_server>>.
+We'll discuss how to export a bare repository copy for this purpose in <<_getting_git_on_a_server>>.
 
 This is also a nice option for quickly grabbing work from someone else's working repository.
 If you and a co-worker are working on the same project and they want you to check something out, running a command like `git pull /home/john/project` is often easier than them pushing to a remote server and you pulling down.


### PR DESCRIPTION
The original asciidoc link name displayed to the reader was
"Git on the Server", which is in fact the very name of the
chapter, which is somewhat confusing, so change the link name
to reflect the actual section name.