### PR TITLE
updated all the references to "_git_on_the_server"

### DIFF
--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -60,7 +60,7 @@ If you want to get a copy of an existing Git repository -- for example, a projec
 If you're familiar with other VCS systems such as Subversion, you'll notice that the command is "clone" and not "checkout".
 This is an important distinction -- instead of getting just a working copy, Git receives a full copy of nearly all data that the server has.
 Every version of every file for the history of the project is pulled down by default when you run `git clone`.
-In fact, if your server disk gets corrupted, you can often use nearly any of the clones on any client to set the server back to the state it was in when it was cloned (you may lose some server-side hooks and such, but all the versioned data would be there -- see <<_git_on_the_server>> for more details).
+In fact, if your server disk gets corrupted, you can often use nearly any of the clones on any client to set the server back to the state it was in when it was cloned (you may lose some server-side hooks and such, but all the versioned data would be there -- see <<_getting_git_on_a_server>> for more details).
 
 You clone a repository with `git clone <url>`.(((git commands, clone)))
 For example, if you want to clone the Git linkable library called `libgit2`, you can do so like this:
@@ -84,4 +84,4 @@ That command does the same thing as the previous one, but the target directory i
 
 Git has a number of different transfer protocols you can use.
 The previous example uses the `https://` protocol, but you may also see `git://` or `user@server:path/to/repo.git`, which uses the SSH transfer protocol.
-<<_git_on_the_server>> will introduce all of the available options the server can set up to access your Git repository and the pros and cons of each.
+<<_getting_git_on_a_server>> will introduce all of the available options the server can set up to access your Git repository and the pros and cons of each.

--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -67,7 +67,7 @@ origin    git@github.com:mojombo/grit.git (push)
 This means we can pull contributions from any of these users pretty easily.
 We may additionally have permission to push to one or more of these, though we can't tell that here.
 
-Notice that these remotes use a variety of protocols; we'll cover more about this in <<_git_on_the_server>>.
+Notice that these remotes use a variety of protocols; we'll cover more about this in <<_getting_git_on_a_server>>.
 
 ==== Adding Remote Repositories
 

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -67,7 +67,7 @@ The `git clone` command is used in dozens of places throughout the book, but we'
 
 It's basically introduced and explained in <<_git_cloning>>, where we go through a few examples.
 
-In <<_git_on_the_server>> we look at using the `--bare` option to create a copy of a Git repository with no working directory.
+In <<_getting_git_on_a_server>> we look at using the `--bare` option to create a copy of a Git repository with no working directory.
 
 In <<_bundling>> we use it to unbundle a bundled Git repository.
 


### PR DESCRIPTION
At commit 3ba700370, @rpjday forgot to update all the references to "_git_on_the_server" when he changed it to "_getting_git_on_a_server".

This update fixes that.