### PR TITLE
removed trailing spaces

### DIFF
--- a/book/04-git-server/sections/git-daemon.asc
+++ b/book/04-git-server/sections/git-daemon.asc
@@ -46,13 +46,13 @@ Group=git
 WantedBy=multi-user.target
 ----
 
-You might have noticed that Git daemon is started here with `git` as both group and user. 
+You might have noticed that Git daemon is started here with `git` as both group and user.
 
 Modify it to fit your needs and make sure provided user exists on the system.
 
 Finally, you'll run `systemctl enable git-daemon` to automatically start the service on boot, and can start and stop the service with, respectively, `systemctl start git-daemon` and `systemctl stop git-daemon`.
 
-Until LTS 14.04, Ubuntu used upstart service unit configuration. 
+Until LTS 14.04, Ubuntu used upstart service unit configuration.
 Therefore, on Ubuntu <= 14.04 you can use an Upstart script.
 So, in the following file
 

--- a/book/07-git-tools/sections/debugging.asc
+++ b/book/07-git-tools/sections/debugging.asc
@@ -21,7 +21,7 @@ b8b0618cf6fab (Cheng Renquan  2009-05-26 16:03:07 +0800 70)   KBUILD_VERBOSE = $
 ^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 72) ifndef KBUILD_VERBOSE
 ^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 73)   KBUILD_VERBOSE = 0
 ^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 74) endif
-^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 75) 
+^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 75)
 066b7ed955808 (Michal Marek   2014-07-04 14:29:30 +0200 76) ifeq ($(KBUILD_VERBOSE),1)
 066b7ed955808 (Michal Marek   2014-07-04 14:29:30 +0200 77)   quiet =
 066b7ed955808 (Michal Marek   2014-07-04 14:29:30 +0200 78)   Q =

--- a/book/07-git-tools/sections/stashing-cleaning.asc
+++ b/book/07-git-tools/sections/stashing-cleaning.asc
@@ -280,7 +280,7 @@ This way you can step through each file individually or specify patterns for del
 
 [NOTE]
 ====
-There is a quirky situation where you might need to be extra forceful in asking Git to clean your working directory. 
+There is a quirky situation where you might need to be extra forceful in asking Git to clean your working directory.
 If you happen to be in a working directory under which you've copied or cloned other Git repositories (perhaps as submodules), even `git clean -fd` will refuse to delete those directories.
 In cases like that, you need to add a second `-f` option for emphasis.
 ====


### PR DESCRIPTION
@buzut and @rpjday made some changes and introduced inadvertently space trailing:

```console
$ git blame -L 49,55 master -- book/04-git-server/sections/git-daemon.asc
26c829ee (Buzut            2017-10-07 21:12:57 +0200 49) You might have noticed that Git daemon is started here with `git` as both group and user. 
26c829ee (Buzut            2017-10-07 21:12:57 +0200 50) 
26c829ee (Buzut            2017-10-07 21:12:57 +0200 51) Modify it to fit your needs and make sure provided user exists on the system.
3c5c45a3 (Buzut            2017-10-05 21:28:09 +0200 52) 
e78ad789 (Robert P. J. Day 2017-10-21 11:47:15 -0400 53) Finally, you'll run `systemctl enable git-daemon` to automatically start the service on boot, and can start and stop the service with, respectively, `systemctl start git-daemon` and `systemctl stop git-daemon`.
3c5c45a3 (Buzut            2017-10-05 21:28:09 +0200 54) 
26c829ee (Buzut            2017-10-07 21:12:57 +0200 55) Until LTS 14.04, Ubuntu used upstart service unit configuration. 

$ git blame -L 24,24 master -- book/07-git-tools/sections/debugging.asc
c4ee7884 (Robert P. J. Day 2017-10-03 16:46:57 -0400 24) ^1da177e4c3f4 (Linus Torvalds 2005-04-16 15:20:36 -0700 75) 

$ git blame -L 283,283 master -- book/07-git-tools/sections/stashing-cleaning.asc
8f2274ad (Robert P. J. Day 2017-09-29 14:06:09 -0400 283) There is a quirky situation where you might need to be extra forceful in asking Git to clean your working directory. 
```