### PR TITLE
Minor tweaks/grammar/clarification fixes for "Plumbing and Porcelain"

### DIFF
--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -1,18 +1,18 @@
 [[_plumbing_porcelain]]
 === Plumbing and Porcelain
 
-This book covers how to use Git with 30 or so verbs such as `checkout`, `branch`, `remote`, and so on.
-But because Git was initially a toolkit for a VCS rather than a full user-friendly VCS, it has a bunch of verbs that do low-level work and were designed to be chained together UNIX-style or called from scripts.
-These commands are generally referred to as ``plumbing'' commands, and the more user-friendly commands are called ``porcelain'' commands.
+This book covers primarily how to use Git with 30 or so subcommands such as `checkout`, `branch`, `remote`, and so on.
+But because Git was initially a toolkit for a version control system rather than a full user-friendly VCS, it has a number of subcommands that do low-level work and were designed to be chained together UNIX-style or called from scripts.
+These commands are generally referred to as Git's ``plumbing'' commands, while the more user-friendly commands are called ``porcelain'' commands.
 
-The book's first nine chapters deal almost exclusively with porcelain commands.
+As you will have have noticed by now, this book's first nine chapters deal almost exclusively with porcelain commands.
 But in this chapter, you'll be dealing mostly with the lower-level plumbing commands, because they give you access to the inner workings of Git, and help demonstrate how and why Git does what it does.
 Many of these commands aren't meant to be used manually on the command line, but rather to be used as building blocks for new tools and custom scripts.
 
 When you run `git init` in a new or existing directory, Git creates the `.git` directory, which is where almost everything that Git stores and manipulates is located.
 If you want to back up or clone your repository, copying this single directory elsewhere gives you nearly everything you need.
-This entire chapter basically deals with the stuff in this directory.
-Here's what it looks like:
+This entire chapter basically deals with what you can see in this directory.
+Here's what a newly-initialized `.git` directory typically looks like:
 
 [source,console]
 ----
@@ -26,7 +26,7 @@ objects/
 refs/
 ----
 
-You may see some other files in there, but this is a fresh `git init` repository – it's what you see by default.
+Depending on your version of Git, you may see some additional content there, but this is a fresh `git init` repository -- it's what you see by default.
 The `description` file is used only by the GitWeb program, so don't worry about it.
 The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a `.gitignore` file.
 The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<_git_hooks>>.


### PR DESCRIPTION
I changed the words "verbs" to "subcommands" since many Git commands
don't qualify as verbs -- things like "remote" and "log" and "status".