### PR TITLE
Remove "this can be confusing, because"

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -335,7 +335,7 @@ index 0000000..03902a1
 ----
 
 It's important to note that `git diff` by itself doesn't show all changes made since your last commit -- only changes that are still unstaged.
-This can be confusing, because if you've staged all of your changes, `git diff` will give you no output.
+If you've staged all of your changes, `git diff` will give you no output.
 
 For another example, if you stage the `CONTRIBUTING.md` file and then edit it, you can use `git diff` to see the changes in the file that are staged and the changes that are unstaged.
 If our environment looks like this:


### PR DESCRIPTION
The sentence "If you've staged all of your changes, `git diff` will give you no output." sounds nice by itself, and treats the behavior as a feature to be expected rather than a complication.