### PR TITLE
Update --recursive to --recurse-submodules

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -185,11 +185,11 @@ Submodule path 'DbConnector': checked out 'c3f01dc8862123d317dd46284b05b6892c7b2
 Now your `DbConnector` subdirectory is at the exact state it was in when you committed earlier.
 
 There is another way to do this which is a little simpler, however.
-If you pass `--recursive` to the `git clone` command, it will automatically initialize and update each submodule in the repository.
+If you pass `--recurse-submodules` to the `git clone` command, it will automatically initialize and update each submodule in the repository.
 
 [source,console]
 ----
-$ git clone --recursive https://github.com/chaconinc/MainProject
+$ git clone --recurse-submodules https://github.com/chaconinc/MainProject
 Cloning into 'MainProject'...
 remote: Counting objects: 14, done.
 remote: Compressing objects: 100% (13/13), done.

--- a/book/C-git-commands/1-git-commands.asc
+++ b/book/C-git-commands/1-git-commands.asc
@@ -71,7 +71,7 @@ In <<_getting_git_on_a_server>> we look at using the `--bare` option to create a
 
 In <<_bundling>> we use it to unbundle a bundled Git repository.
 
-Finally, in <<_cloning_submodules>> we learn the `--recursive` option to make cloning a repository with submodules a little simpler.
+Finally, in <<_cloning_submodules>> we learn the `--recurse-submodules` option to make cloning a repository with submodules a little simpler.
 
 Though it's used in many other places through the book, these are the ones that are somewhat unique or where it is used in ways that are a little different.
 


### PR DESCRIPTION
Update the --recursive option to --recurse-submodules for the clone command because --recursive seems to be depreciated in versions > 2.11.0