### PR TITLE
fix(typo): Change show merge commits

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -205,7 +205,7 @@ Then, you can see the previous commit by specifying `HEAD^`, which means ``the p
 ----
 $ git show HEAD^
 commit d921970aadf03b3cf0e71becdaab3147ba71cdef
-Merge: 1c002dd... 35cfb2b...
+Merge: 1c36188... 35cfb2b...
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Thu Dec 11 15:08:43 2008 -0800
 


### PR DESCRIPTION
I think there is a typo in here - it should be both commit parents, and now there are ancestors in a single branch, here is a gherkin description

```gherkin
Given merge commit of two branches
When run `git show` on merge commit
Then it shows both merge commit parents
```

```
*   111 Merge branch ...
|\  
| * bbb Second
|/
* aaa First
```

```
git show HEAD

commit 111 (HEAD -> develop, origin/develop, origin/HEAD)
Merge: aaa bbb
```
