### PR TITLE
taking into account the syntax of Bazaar

### DIFF
--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -82,14 +82,12 @@ Bazaar uses the same model as Git to ignore files, but also has two features whi
 The complete description may be found in http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/ignore-help.html[the documentation].
 The two features are:
 
-1. "!!" at the beginning of a character string takes prevail on "!" at the beginning of the string, which allows to ignore some files that would have been included with "!"
-2. character strings starting with "RE:".
-What follows "RE:" is a http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/patterns-help.html[regular expression].
-Git does not allow the use of regular expressions, only shell globs.
+1. "!!" allows you to ignore certain file patterns even if they're specified using a "!" rule.
+2. "RE:" at the beginning of a line allows you to specify a https://docs.python.org/3/library/re.html[Python regular expression] (Git only allows shell globs).
 
 As a consequence, there are two different situations to consider:
 
-1. If the `.bzrignore` file does not contain any of these two specific prefixes, then you can simply make a symbolic link to it in the repository.
+1. If the `.bzrignore` file does not contain any of these two specific prefixes, then you can simply make a symbolic link to it in the repository: `ln -s .bzrignore .git/info/exclude`
 2. Otherwise, you must create the `.git/info/exclude` file and adapt it to ignore exactly the same files in `.bzrignore`.
 
 Whatever the case is, you will have to remain vigilant against any change of `.bzrignore` to make sure that the `.git/info/exclude` file always reflects `.bzrignore`.

--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -74,11 +74,28 @@ $ git fetch
 
 ===== Ignore what is ignored with .bzrignore
 
-As the format of the `.bzrignore` file is completely compatible with `.gitignore`'s one, and as you shouldn't make a `.gitignore` file in your repository, it is enough to make a symbolic link to `.bzrignore` so that the potential changes of `.bzrignore` are taken into account:
-[source,console]
-----
-$ ln -s .bzrignore .git/info/exclude
-----
+Since you are working on a project managed with Bazaar, you shouldn't create a `.gitignore` file because you _may_ accidentally set it under version control and the other people working with Bazaar would be disturbed.
+The solution is to create the `.git/info/exclude` file either as a symbolic link or as a regular file.
+We'll see later on how to solve this question.
+
+Bazaar uses the same model as Git to ignore files, but also has two features which don't have an equivalent into Git.
+The complete description may be found in http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/ignore-help.html[the documentation].
+The two features are:
+
+1. "!!" at the beginning of a character string takes prevail on "!" at the beginning of the string, which allows to ignore some files that would have been included with "!"
+2. character strings starting with "RE:".
+What follows "RE:" is a http://doc.bazaar.canonical.com/bzr.2.7/en/user-reference/patterns-help.html[regular expression].
+Git does not allow the use of regular expressions, only shell globs.
+
+As a consequence, there are two different situations to consider:
+
+1. If the `.bzrignore` file does not contain any of these two specific prefixes, then you can simply make a symbolic link to it in the repository.
+2. Otherwise, you must create the `.git/info/exclude` file and adapt it to ignore exactly the same files in `.bzrignore`.
+
+Whatever the case is, you will have to remain vigilant against any change of `.bzrignore` to make sure that the `.git/info/exclude` file always reflects `.bzrignore`.
+Indeed, if the `.bzrignore` file were to change and contained one or more lines starting with "!!" or "RE:", Git not being able to interpret these lines, you'll have to adapt your `.git/info/exclude` file to ignore the same files as the ones ignored with `.bzrignore`.
+Moreover, if the `.git/info/exclude` file was a symbolic link, you'll have to first delete the symbolic link, copy `.bzrignore` to `.git/info/exclude` and then adapt the latter.
+However, be careful with its creation because with Git it is impossible to re-include a file if a parent directory of that file is excluded.
 
 ===== Fetch the changes of the remote repository
 

--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -129,12 +129,15 @@ $ git reset --hard HEAD
 ===== Ignoring the files that were ignored with .bzrignore
 
 Now let's have a look at the files to ignore.
-As `.bzrignore`'s format is completely compatible with `.gitignore`'s format, the simplest is to rename your `.bzrignore` file.
-You will also have to create a commit that contains this change for the migration:
+The first thing to do is to rename `.bzrignore` into `.gitignore`.
+Moreover, if the `.bzrignore` file contains one or several lines starting with "!!" or "RE:", you'll have to modify it and perhaps create several `.gitignore` files in order to ignore exactly the same files that `.bzrignore` allowed.
+
+Finally, you will have to create a commit that contains this modification for the migration:
 
 [source,console]
 ----
 $ git mv .bzrignore .gitignore
+$ # modify .gitignore if needed
 $ git commit -am 'Migration from Bazaar to Git'
 ----
 

--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -130,7 +130,7 @@ $ git reset --hard HEAD
 
 Now let's have a look at the files to ignore.
 The first thing to do is to rename `.bzrignore` into `.gitignore`.
-Moreover, if the `.bzrignore` file contains one or several lines starting with "!!" or "RE:", you'll have to modify it and perhaps create several `.gitignore` files in order to ignore exactly the same files that `.bzrignore` allowed.
+If the `.bzrignore` file contains one or several lines starting with "!!" or "RE:", you'll have to modify it and perhaps create several `.gitignore` files in order to ignore exactly the same files that Bazaar was ignoring.
 
 Finally, you will have to create a commit that contains this modification for the migration:
 


### PR DESCRIPTION
Bazaar has a more extended syntax than Git to ignore some files.
Then it is necessary to adapt the exclusion file of the Git repository
to take into account the possible incompatibilities.