### PR TITLE
fixed minor grammar mistake

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -268,7 +268,7 @@ Like `reset`, `checkout` manipulates the three trees, and it is a bit different 
 Running `git checkout [branch]` is pretty similar to running `git reset --hard [branch]` in that it updates all three trees for you to look like `[branch]`, but there are two important differences.
 
 First, unlike `reset --hard`, `checkout` is working-directory safe; it will check to make sure it's not blowing away files that have changes to them.
-Actually, it's a bit smarter than that -- it tries to do a trivial merge in the Working Directory, so all of the files you _haven't_ changed in will be updated.
+Actually, it's a bit smarter than that -- it tries to do a trivial merge in the Working Directory, so all of the files you _haven't_ changed will be updated.
 `reset --hard`, on the other hand, will simply replace everything across the board without checking.
 
 The second important difference is how `checkout` updates HEAD.


### PR DESCRIPTION
Guessing this should be from/to, as that's what a "trivial merge" would probably do:
so all of the files you _haven't_ changed in will be updated.   <=was
so all of the files you _haven't_ changed will be updated.       <=suggesting as simpler than the other option:
so all of the files you _haven't_ changed in it will be updated. <= possible alternative