### PR TITLE
Add a missing step of objects manipulate procedure

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -274,6 +274,13 @@ $ echo 'third commit'  | git commit-tree 3c4e9c -p cac0cab
 ----
 
 Each of the three commit objects points to one of the three snapshot trees you created.
+You will need to update the head of master branch with the third commit's refs:
+
+[source, console]
+----
+git update-ref refs/heads/master 1a410ef
+----
+
 Oddly enough, you have a real Git history now that you can view with the `git log` command, if you run it on the last commit SHA-1:
 
 [source,console]


### PR DESCRIPTION
If `refs/heads/master` was not updated with sha1 value of some commit, `git log` will complain. We need to include a step to update it.