### PR TITLE
Update remote-branches.asc: Resolves #963

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -132,7 +132,7 @@ This gives you a local branch that you can work on that starts where `origin/ser
 (((branches, tracking)))(((branches, upstream)))
 Checking out a local branch from a remote-tracking branch automatically creates what is called a ``tracking branch'' (and the branch it tracks is called an ``upstream branch'').
 Tracking branches are local branches that have a direct relationship to a remote branch.
-If you're on a tracking branch and type `git pull`, Git automatically knows which server to fetch from and branch to merge into.
+If you're on a tracking branch and type `git pull`, Git automatically knows which server to fetch from and which branch to merge in.
 
 When you clone a repository, it generally automatically creates a `master` branch that tracks `origin/master`.
 However, you can set up other tracking branches if you wish -- ones that track branches on other remotes, or don't track the `master` branch.


### PR DESCRIPTION
Clarifying "merge in" vs "merge into".