### PR TITLE
git cat-file -p master^{tree} in other shells

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -139,11 +139,12 @@ $ git cat-file -p master^{tree}
 The `master^{tree}` syntax specifies the tree object that is pointed to by the last commit on your `master` branch.
 Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
 
-**NOTE**: while using `master^{tree}` syntax if you have error try the following
-
-* On Windows, in PowerShell and cmd.exe, ^ is used for escaping. There, you can alternatively write git `cat-file -p master^^{tree}`
-* In zsh `^` is a globbing character so use them with quotes `git cat-file -p "master^{tree}"`
-* In bash the command works without quotes
+[NOTE]
+====
+* Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax
+* In PowerShell or CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p mater^^{tree}`
+* If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
+====
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -139,6 +139,12 @@ $ git cat-file -p master^{tree}
 The `master^{tree}` syntax specifies the tree object that is pointed to by the last commit on your `master` branch.
 Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
 
+**NOTE**: while using `master^{tree}` syntax if you have error try the following
+
+* On Windows, in PowerShell and cmd.exe, ^ is used for escaping. There, you can alternatively write git `cat-file -p master^^{tree}`
+* In zsh `^` is a globbing character so use them with quotes `git cat-file -p "master^{tree}"`
+* In bash the command works without quotes
+
 [source,console]
 ----
 $ git cat-file -p 99f1a6d12cb4b6f19c8655fca46c3ecf317074e0

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -141,7 +141,11 @@ Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
 
 [NOTE]
 ====
-Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax. In PowerShell or CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p mater^^{tree}`. If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
+Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax.
+
+In PowerShell or CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p mater^^{tree}`.
+
+If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
 ====
 
 [source,console]

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -141,9 +141,7 @@ Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
 
 [NOTE]
 ====
-* Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax
-* In PowerShell or CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p mater^^{tree}`
-* If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
+Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax. In PowerShell or CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p mater^^{tree}`. If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
 ====
 
 [source,console]

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -139,6 +139,12 @@ $ git cat-file -p master^{tree}
 The `master^{tree}` syntax specifies the tree object that is pointed to by the last commit on your `master` branch.
 Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
 
+[source,console]
+----
+$ git cat-file -p 99f1a6d12cb4b6f19c8655fca46c3ecf317074e0
+100644 blob 47c6340d6459e05787f644c2447d2595f5d3a54b      simplegit.rb
+----
+
 [NOTE]
 ====
 Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax.
@@ -147,12 +153,6 @@ In PowerShell or CMD on Windows, the `^` character is used for escaping, so you 
 
 If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`
 ====
-
-[source,console]
-----
-$ git cat-file -p 99f1a6d12cb4b6f19c8655fca46c3ecf317074e0
-100644 blob 47c6340d6459e05787f644c2447d2595f5d3a54b      simplegit.rb
-----
 
 Conceptually, the data that Git is storing looks something like this:
 


### PR DESCRIPTION
usage of `git cat-file -p master^{tree} command` in other environments as specified in this answer https://stackoverflow.com/a/17121954/2445295 thanks to @Mellbourn