### PR TITLE
Update Ch9 section about Mercurial imports to match current hg-fast-export release

### DIFF
--- a/book/09-git-and-other-scms/sections/import-hg.asc
+++ b/book/09-git-and-other-scms/sections/import-hg.asc
@@ -52,6 +52,8 @@ In this example, we want our file to look like this:
 "bob jones <bob <AT> company <DOT> com>"="Bob Jones <bob@company.com>"
 ----
 
+The same kind of mapping file can be used to rename branches and tags when the Mercurial name is not allowed by Git.
+
 The next step is to create our new Git repository, and run the export script:
 
 [source,console]
@@ -61,7 +63,7 @@ $ cd /tmp/converted
 $ /tmp/fast-export/hg-fast-export.sh -r /tmp/hg-repo -A /tmp/authors
 ----
 
-The `-r` flag tells hg-fast-export where to find the Mercurial repository we want to convert, and the `-A` flag tells it where to find the author-mapping file.
+The `-r` flag tells hg-fast-export where to find the Mercurial repository we want to convert, and the `-A` flag tells it where to find the author-mapping file (branch and tag mapping files are specified by the `-B` and `-T` flags respectively).
 The script parses Mercurial changesets and converts them into a script for Git's "fast-import" feature (which we'll discuss in detail a bit later on).
 This takes a bit (though it's _much_ faster than it would be over the network), and the output is fairly verbose:
 

--- a/book/09-git-and-other-scms/sections/import-hg.asc
+++ b/book/09-git-and-other-scms/sections/import-hg.asc
@@ -5,7 +5,7 @@ Since Mercurial and Git have fairly similar models for representing versions, an
 
 [source,console]
 ----
-$ git clone http://repo.or.cz/r/fast-export.git /tmp/fast-export
+$ git clone https://github.com/frej/fast-export.git
 ----
 
 The first step in the conversion is to get a full clone of the Mercurial repository you want to convert:

--- a/book/09-git-and-other-scms/sections/import-hg.asc
+++ b/book/09-git-and-other-scms/sections/import-hg.asc
@@ -38,16 +38,18 @@ Joe Smith <joe@company.com>
 ----
 
 In this example, the same person (Bob) has created changesets under four different names, one of which actually looks correct, and one of which would be completely invalid for a Git commit.
-Hg-fast-export lets us fix this by adding `={new name and email address}` at the end of every line we want to change, and removing the lines for any usernames that we want to leave alone.
+Hg-fast-export lets us fix this by turning each line into a rule: `"<input>"="<output>"`, mapping an `<input>` to an `<output>`.
+Inside the `<input>` and `<output>` strings, all escape sequences understood by the python `string_escape` encoding are supported.
+If the author mapping file does not contain a matching `<input>`, that author will be sent on to Git unmodified.
 If all the usernames look fine, we won't need this file at all.
 In this example, we want our file to look like this:
 
 [source]
 ----
-bob=Bob Jones <bob@company.com>
-bob@localhost=Bob Jones <bob@company.com>
-bob <bob@company.com>=Bob Jones <bob@company.com>
-bob jones <bob <AT> company <DOT> com>=Bob Jones <bob@company.com>
+"bob"="Bob Jones <bob@company.com>"
+"bob@localhost"="Bob Jones <bob@company.com>"
+"bob <bob@company.com>"="Bob Jones <bob@company.com>"
+"bob jones <bob <AT> company <DOT> com>"="Bob Jones <bob@company.com>"
 ----
 
 The next step is to create our new Git repository, and run the export script:


### PR DESCRIPTION
As maintainer of hg-fast-export I have received at least one issue (frej/fast-export#116) due to the example in Ch9 no longer working with a recent hg-fast-export. In order to avoid future user confusion I propose the changes in this pull request.