### PR TITLE
Fix bzr fastimport plugin install guide

### DIFF
--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -34,8 +34,8 @@ If the package is not available, you may install it as a plugin:
 
 [source,console]
 ----
-$ mkdir --parents ~/.bazaar/plugins/bzr     # creates the necessary folders for the plugins
-$ cd ~/.bazaar/plugins/bzr
+$ mkdir --parents ~/.bazaar/plugins     # creates the necessary folders for the plugins
+$ cd ~/.bazaar/plugins
 $ bzr branch lp:bzr-fastimport fastimport   # imports the fastimport plugin
 $ cd fastimport
 $ sudo python setup.py install --record=files.txt   # installs the plugin


### PR DESCRIPTION
Bzr would not find plugin in the old place on Ubuntu 16.04.