### PR TITLE
Fix comma splices

### DIFF
--- a/book/06-github/sections/1-setting-up-account.asc
+++ b/book/06-github/sections/1-setting-up-account.asc
@@ -9,7 +9,7 @@ image::images/signup.png[The GitHub sign-up form.]
 
 The next thing you'll see is the pricing page for upgraded plans, but it's safe to ignore this for now.
 GitHub will send you an email to verify the address you provided.
-Go ahead and do this, it's pretty important (as we'll see later).
+Go ahead and do this; it's pretty important (as we'll see later).
 
 [NOTE]
 ====

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -55,7 +55,7 @@ Tony is looking for code to run on his Arduino programmable microcontroller and 
 .The project we want to contribute to.
 image::images/blink-01-start.png[The project we want to contribute to.]
 
-The only problem is that the blinking rate is too fast, we think it's much nicer to wait 3 seconds instead of 1 in between each state change.
+The only problem is that the blinking rate is too fast. We think it's much nicer to wait 3 seconds instead of 1 in between each state change.
 So let's improve the program and submit it back to the project as a proposed change.
 
 First, we click the 'Fork' button as mentioned earlier to get our own copy of the project.


### PR DESCRIPTION
In two instances, a comma was used when other punctuation would have
been more appropriate to seperate the two independant caluses.