### PR TITLE
Get Version from git describe not travis envvar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@ namespace :book do
 
     `cp progit.asc progit.asc.bak`
     begin
-      version_string = `git describe --tags`.chomp
+      version_string = ENV['TRAVIS_TAG'] || `git describe --tags`.chomp
+      if version_string.empty?
+        version_string = '0'
+      end
       text = File.read('progit.asc')
       new_contents = text.gsub("$$VERSION$$", version_string).gsub("$$DATE$$", Time.now.strftime("%Y-%m-%d"))
       File.open("progit.asc", "w") {|file| file.puts new_contents }

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ namespace :book do
 
     `cp progit.asc progit.asc.bak`
     begin
-      version_string = ENV['TRAVIS_TAG'] || '0'
+      version_string = `git describe --tags`.chomp
       text = File.read('progit.asc')
       new_contents = text.gsub("$$VERSION$$", version_string).gsub("$$DATE$$", Time.now.strftime("%Y-%m-%d"))
       File.open("progit.asc", "w") {|file| file.puts new_contents }


### PR DESCRIPTION
Users should get version number from git rather than a
possibly non-existent environment variable.