### PR TITLE
signing.asc: Standardize on using "$" to represent command markup

### DIFF
--- a/book/07-git-tools/sections/signing.asc
+++ b/book/07-git-tools/sections/signing.asc
@@ -22,14 +22,14 @@ If you don't have a key installed, you can generate one with `gpg --gen-key`.
 
 [source,console]
 ----
-gpg --gen-key
+$ gpg --gen-key
 ----
 
 Once you have a private key to sign with, you can configure Git to use it for signing things by setting the `user.signingkey` config setting.
 
 [source,console]
 ----
-git config --global user.signingkey 0A46826A
+$ git config --global user.signingkey 0A46826A
 ----
 
 Now Git will use your key by default to sign tags and commits if you want.


### PR DESCRIPTION
I propose that *all* command markup (even single-line markup)
use a dollar sign to signify a command, just for consistency.
Otherwise, it looks kind of weird as it bounces back and forth
between the two.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>