### PR TITLE
advanced-merging.asc: correct obvious typo, "lose" -> "preserve"

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -19,7 +19,7 @@ While we covered some basics on resolving merge conflicts in <<ch03-git-branchin
 First of all, if at all possible, try to make sure your working directory is clean before doing a merge that may have conflicts.
 If you have work in progress, either commit it to a temporary branch or stash it.
 This makes it so that you can undo *anything* you try here.
-If you have unsaved changes in your working directory when you try a merge, some of these tips may help you lose that work.
+If you have unsaved changes in your working directory when you try a merge, some of these tips may help you preserve that work.
 
 Let's walk through a very simple example.
 We have a super simple Ruby file that prints 'hello world'.


### PR DESCRIPTION
Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>