### PR TITLE
mohamedvolt

### DIFF
--- a/LICENSE.asc
+++ b/LICENSE.asc
@@ -1,1 +1,1 @@
-This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+formatedhar.vatThis work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
Seated.batVersion 
Contact Support
Return to GitHub
Managing Remotes / Changing a remote's URL
 	
Changing a remote's URL
MAC WINDOWS LINUX
The git remote set-url command changes an existing remote repository URL.

Tip: For information on the difference between HTTPS and SSH URLs, see "Which remote URL should I use?"
The git remote set-url command takes two arguments:

An existing remote name. For example, origin or upstream are two common choices.
A new URL for the remote. For example:

If you're updating to use HTTPS, your URL might look like:

https://github.com/USERNAME/REPOSITORY.git
If you're updating to use SSH, your URL might look like:

git@github.com:USERNAME/REPOSITORY.git
Switching remote URLs from SSH to HTTPS
