### PR TITLE
Tree objects don't nec. point to trees

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -125,7 +125,7 @@ blob
 The next type of Git object we'll examine is the _tree_, which solves the problem of storing the filename and also allows you to store a group of files together.
 Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
 All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
-A single tree object contains one or more entries, each containing a SHA-1 pointer to a blob or subtree with its associated mode, type, and filename.
+A single tree object contains one or more entries, each of which is the SHA-1 hash of a blob or subtree with its associated mode, type, and filename.
 For example, the most recent tree in a project may look something like this:
 
 [source,console]

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -125,7 +125,7 @@ blob
 The next type of Git object we'll examine is the _tree_, which solves the problem of storing the filename and also allows you to store a group of files together.
 Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
 All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
-A single tree object contains one or more tree entries, each of which contains a SHA-1 pointer to a blob or subtree with its associated mode, type, and filename.
+A single tree object contains one or more entries, each containing a SHA-1 pointer to a blob or subtree with its associated mode, type, and filename.
 For example, the most recent tree in a project may look something like this:
 
 [source,console]


### PR DESCRIPTION
> "A single tree object contains one or more tree entries"

The language suggests that each tree object contains (at least one) reference to another tree object, which is wrong.