### PR TITLE
Remove quotes from index entries

### DIFF
--- a/book/B-embedding-git/sections/dulwich.asc
+++ b/book/B-embedding-git/sections/dulwich.asc
@@ -1,6 +1,6 @@
 === Dulwich
 
-(((Dulwich)))((("Python")))
+(((Dulwich)))(((Python)))
 There is also a pure-Python Git implementation - Dulwich.
 The project is hosted under https://www.dulwich.io/
 It aims to provide an interface to git repositories (both local and remote) that doesn't call out to git directly but instead uses pure Python.

--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -1,6 +1,6 @@
 === go-git
 
-(((go-git)))((("Go")))
+(((go-git)))(((Go)))
 In case you want to integrate Git into a service written in Golang, there also is a pure Go library implementation.
 This implementation does not have any native dependencies and thus is not prone to manual memory management errors.
 It is also transparent for the standard Golang performance analysis tooling like CPU, Memory profilers, race detector, etc.

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -1,6 +1,6 @@
 === JGit
 
-(((jgit)))(((java)))
+(((jgit)))(((Java)))
 If you want to use Git from within a Java program, there is a fully featured Git library called JGit.
 JGit is a relatively full-featured implementation of Git written natively in Java, and is widely used in the Java community.
 The JGit project is under the Eclipse umbrella, and its home can be found at http://www.eclipse.org/jgit[].


### PR DESCRIPTION
Following up on discussion at https://github.com/progit/progit2/pull/999#discussion_r198919430.

Remove unnecessary quotes from index entries in Embedding section. 