### PR TITLE
HEAD~3 is equivalent to HEAD~~~, not HEAD^^^

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -264,11 +264,11 @@ Date:   Fri Nov 7 13:47:59 2008 -0500
     ignore *.gem
 ----
 
-This can also be written `HEAD^^^`, which again is the first parent of the first parent of the first parent:
+This can also be written `HEAD~~~`, which again is the first parent of the first parent of the first parent:
 
 [source,console]
 ----
-$ git show HEAD^^^
+$ git show HEAD~~~
 commit 1c3618887afb5fbcbea25b7c013f4e2114448b8d
 Author: Tom Preston-Werner <tom@mojombo.com>
 Date:   Fri Nov 7 13:47:59 2008 -0500


### PR DESCRIPTION
Fixing a typo where you wrote HEAD^^^ instead of HEAD~~~ (occurs in two places).