### PR TITLE
Update ssh-keygen with secure password encryption

### DIFF
--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -36,8 +36,8 @@ d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 ----
 
 First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
-
-However, if you do use a password, make sure to add the `-o` option. You can also use the `ssh-agent` tool to prevent having to enter the password each time.
+However, if you do use a password, make sure to add the `-o` option.
+You can also use the `ssh-agent` tool to prevent having to enter the password each time.
 
 Now, each user that does this has to send their public key to you or whoever is administrating the Git server (assuming you're using an SSH server setup that requires public keys).
 All they have to do is copy the contents of the `.pub` file and email it.

--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -23,7 +23,7 @@ If you don't have these files (or you don't even have a `.ssh` directory), you c
 
 [source,console]
 ----
-$ ssh-keygen
+$ ssh-keygen -o
 Generating public/private rsa key pair.
 Enter file in which to save the key (/home/schacon/.ssh/id_rsa):
 Created directory '/home/schacon/.ssh'.
@@ -35,7 +35,7 @@ The key fingerprint is:
 d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 ----
 
-First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
+First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key. However, if you do use a password, make sure to add the `-o` option. You can also use the `ssh-agent` tool to prevent having to enter the password each time.
 
 Now, each user that does this has to send their public key to you or whoever is administrating the Git server (assuming you're using an SSH server setup that requires public keys).
 All they have to do is copy the contents of the `.pub` file and email it.

--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -35,7 +35,9 @@ The key fingerprint is:
 d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 ----
 
-First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key. However, if you do use a password, make sure to add the `-o` option. You can also use the `ssh-agent` tool to prevent having to enter the password each time.
+First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
+
+However, if you do use a password, make sure to add the `-o` option. You can also use the `ssh-agent` tool to prevent having to enter the password each time.
 
 Now, each user that does this has to send their public key to you or whoever is administrating the Git server (assuming you're using an SSH server setup that requires public keys).
 All they have to do is copy the contents of the `.pub` file and email it.


### PR DESCRIPTION
I know the documentation here suggests you don't need a password, but I am suggesting this change for two reasons:

1) If the user does want a password, they will want to use the -o option. Not using the -o option makes the password practically worthless. See here for details: https://latacora.singles/2018/08/03/the-default-openssh.html

2) This documentation comes up on the top 10 Google search results for "how do I make an ssh key". It's likely that ssh users (even experienced ones) may use this guide to create new keys. It is important to get users into the habit of using the -o option, since it should be the default for the command anyway, but for whatever reason was never updated as such.