### PR TITLE
Explain -o option in ssh-keygen

### DIFF
--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -36,7 +36,7 @@ d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
 ----
 
 First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
-However, if you do use a password, make sure to add the `-o` option.
+However, if you do use a password, make sure to add the `-o` option; it saves the private key in a format that is more resistant to brute-force password cracking than is the default format.
 You can also use the `ssh-agent` tool to prevent having to enter the password each time.
 
 Now, each user that does this has to send their public key to you or whoever is administrating the Git server (assuming you're using an SSH server setup that requires public keys).


### PR DESCRIPTION
Add brief explanation of

ssh-keygen -o

option.