### PR TITLE
Fixed the author name

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -284,7 +284,7 @@ For example, if you want to see which commits modifying test files in the Git so
 
 [source,console]
 ----
-$ git log --pretty="%h - %s" --author=gitster --since="2008-10-01" \
+$ git log --pretty="%h - %s" --author=Junio Hamano --since="2008-10-01" \
    --before="2008-11-01" --no-merges -- t/
 5610e3b - Fix testcase failure when extended attributes are in use
 acd3b9e - Enhance hold_lock_file_for_{update,append}() API

--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -284,7 +284,7 @@ For example, if you want to see which commits modifying test files in the Git so
 
 [source,console]
 ----
-$ git log --pretty="%h - %s" --author=Junio Hamano --since="2008-10-01" \
+$ git log --pretty="%h - %s" --author='Junio C Hamano' --since="2008-10-01" \
    --before="2008-11-01" --no-merges -- t/
 5610e3b - Fix testcase failure when extended attributes are in use
 acd3b9e - Enhance hold_lock_file_for_{update,append}() API


### PR DESCRIPTION
In the section 2.3, if one wants to see the changes made by the author
Junio Hamano, the author name cannot be gitster. Fixed the same.