### PR TITLE
Always use "50 characters" as subject line limit

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -92,7 +92,7 @@ Then, your editor will open to something like this for your placeholder commit m
 
 [source,text]
 ----
-Subject line (try to keep under 60 characters)
+Subject line (try to keep under 50 characters)
 
 Multi-line description of commit,
 feel free to be detailed.


### PR DESCRIPTION
Very minor detail, but to remove a source of confusion I think that
the commit message template and the example output should be 
consistent and both show "50 characters" as the subject line limit.