### PR TITLE
change the describe of when should force the removal with the -f option

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -533,7 +533,7 @@ Changes to be committed:
 ----
 
 The next time you commit, the file will be gone and no longer tracked.
-If you modified the file and added it to the staging area already, you must force the removal with the `-f` option.
+If you modified the file or had already added it to the staging area, you must force the removal with the `-f` option.
 This is a safety feature to prevent accidental removal of data that hasn't yet been recorded in a snapshot and that can't be recovered from Git.
 
 Another useful thing you may want to do is to keep the file in your working tree but remove it from your staging area.


### PR DESCRIPTION
whether the file is modified or has been added to the staging area, the -f option is needed to force the removal