### PR TITLE
Change suggested Git version from 2.0.0 to 2.8.0

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -6,7 +6,7 @@ You can either install it as a package or via another installer, or download the
 
 [NOTE]
 ====
-This book was written using Git version *2.0.0*.
+This book was written using Git version *2.8.0*.
 Though most of the commands we use should work even in ancient versions of Git, some of them might not or might act slightly differently if you're using an older version.
 Since Git is quite excellent at preserving backwards compatibility, any version after 2.0 should work just fine.
 ====


### PR DESCRIPTION
At the end of the next sub-chapter of the tutorial (Getting-Started-First-Time-Git-Setup) we are presented with code example:
`$ git config --show-origin rerere.autoUpdate
file:/home/johndoe/.gitconfig	false`
but that function was implemented in 2.8.0 and doesn't work with git 2.0.0.
I've installed git from Ubuntu repos, git ver 2.7.0, and was surprised that something didn't work, even though version used was far more up to date than 2.0.0. 

An alternative would be to add a warning for the reader in  Getting-Started-First-Time-Git-Setup, that `git config --show-origin` works only in 2.8.0 and later.