### PR TITLE
+config paths for Debian, & +command to view all configs

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -8,18 +8,25 @@ You can also change them at any time by running through the commands again.
 Git comes with a tool called `git config` that lets you get and set configuration variables that control all aspects of how Git looks and operates.(((git commands, config)))
 These variables can be stored in three different places:
 
-1. `/etc/gitconfig` file: Contains values applied to every user on the system and all their repositories.
+1. `/etc/gitconfig` (/usr/local/etc/gitconfig on Debian): Contains values applied to every user on the system and all their repositories.
   If you pass the option `--system` to `git config`, it reads and writes from this file specifically.
   (Because this is a system configuration file, you would need administrative or superuser privilege to make changes to it.)
-2. `~/.gitconfig` or `~/.config/git/config` file: Values specific personally to you, the user.
+2. `~/.gitconfig` or `~/.config/git/config` (note ~ is root's home dir): Contains values specific personally to you, the user.
   You can make Git read and write to this file specifically by passing the `--global` option, and this affects _all_ of the repositories you work with on your system.
-3. `config` file in the Git directory (that is, `.git/config`) of whatever repository you're currently using: Specific to that single repository.
+3. `config` file in the Git directory (that is, `.git/config`) of whatever repository you're currently using: Contains values specific to that repository.
   You can force Git to read from and write to this file with the `--local` option, but that is in fact the default.
   (Unsurprisingly, you need to be located somewhere in a Git repository for this option to work properly.)
 
 Each level overrides values in the previous level, so values in `.git/config` trump those in `/etc/gitconfig`.
 
-On Windows systems, Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).
+You can view all of your settings and where they are coming from using:
+
+[source,console]
+----
+$sudo git config --list --show-origin
+----
+
+*Windows:* Git looks for the `.gitconfig` file in the `$HOME` directory (`C:\Users\$USER` for most people).
 It also still looks for `/etc/gitconfig`, although it's relative to the MSys root, which is wherever you decide to install Git on your Windows system when you run the installer.
 If you are using version 2.x or later of Git for Windows, there is also a system-level config file at
 `C:\Documents and Settings\All Users\Application Data\Git\config` on Windows XP, and in `C:\ProgramData\Git\config` on Windows Vista and newer.


### PR DESCRIPTION
The config paths as they were didn't work for me on Debian Stretch.  So added paths for them.
Also added a command to show all current settings and where they're coming from.  Ref: https://stackoverflow.com/questions/2114111/where-does-git-config-global-get-written-to

Also paralleled text for 3 items, and bold faced heading for Windows.