### PR TITLE
Remove the empty version line

### DIFF
--- a/progit.asc
+++ b/progit.asc
@@ -1,7 +1,6 @@
 Pro Git
 =======
 Scott Chacon; Ben Straub
-
 :doctype: book
 :docinfo:
 :toc:


### PR DESCRIPTION
f2678ab introduced the management of version strings by command line
attributes, but left an empty line after the authors. This seems to
upset Asciidoctor which finds an error elsewhere.

Removing the empty line seems to make it back happy.

fix #1134