### PR TITLE
interactive staging: update prompts to include "[]" for shortcuts

### DIFF
--- a/book/07-git-tools/sections/interactive-staging.asc
+++ b/book/07-git-tools/sections/interactive-staging.asc
@@ -16,8 +16,8 @@ $ git add -i
   3:    unchanged        +5/-1 lib/simplegit.rb
 
 *** Commands ***
-  1: status     2: update      3: revert     4: add untracked
-  5: patch      6: diff        7: quit       8: help
+  1: [s]tatus     2: [u]pdate      3: [r]evert     4: [a]dd untracked
+  5: [p]atch      6: [d]iff        7: [q]uit       8: [h]elp
 What now>
 ----
 
@@ -61,8 +61,8 @@ Update>>
 updated 2 paths
 
 *** Commands ***
-  1: status     2: update      3: revert     4: add untracked
-  5: patch      6: diff        7: quit       8: help
+  1: [s]tatus     2: [u]pdate      3: [r]evert     4: [a]dd untracked
+  5: [p]atch      6: [d]iff        7: [q]uit       8: [h]elp
 What now> 1
            staged     unstaged path
   1:        +0/-1      nothing TODO
@@ -76,8 +76,8 @@ If you want to unstage the `TODO` file at this point, you use the `3` or `r` (fo
 [source,console]
 ----
 *** Commands ***
-  1: status     2: update      3: revert     4: add untracked
-  5: patch      6: diff        7: quit       8: help
+  1: [s]tatus     2: [u]pdate      3: [r]evert     4: [a]dd untracked
+  5: [p]atch      6: [d]iff        7: [q]uit       8: [h]elp
 What now> 3
            staged     unstaged path
   1:        +0/-1      nothing TODO
@@ -97,8 +97,8 @@ Looking at your Git status again, you can see that you’ve unstaged the `TODO` 
 [source,console]
 ----
 *** Commands ***
-  1: status     2: update      3: revert     4: add untracked
-  5: patch      6: diff        7: quit       8: help
+  1: [s]tatus     2: [u]pdate      3: [r]evert     4: [a]dd untracked
+  5: [p]atch      6: [d]iff        7: [q]uit       8: [h]elp
 What now> 1
            staged     unstaged path
   1:    unchanged        +0/-1 TODO
@@ -113,8 +113,8 @@ This is much like specifying `git diff --cached` on the command line:
 [source,console]
 ----
 *** Commands ***
-  1: status     2: update      3: revert     4: add untracked
-  5: patch      6: diff        7: quit       8: help
+  1: [s]tatus     2: [u]pdate      3: [r]evert     4: [a]dd untracked
+  5: [p]atch      6: [d]iff        7: [q]uit       8: [h]elp
 What now> 6
            staged     unstaged path
   1:        +1/-1      nothing index.html


### PR DESCRIPTION
The newer form of interactive staging uses square brackets
to emphasize single-letter shortcuts.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>