### PR TITLE
maintaining: explain how "git describe" works with lightweight tags

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -497,7 +497,7 @@ This way, you can export a snapshot or build and name it something understandabl
 In fact, if you build Git from source code cloned from the Git repository, `git --version` gives you something that looks like this.
 If you're describing a commit that you have directly tagged, it gives you simply the tag name.
 
-The `git describe` command favors annotated tags (tags created with the `-a` or `-s` flag), so release tags should be created this way if you're using `git describe`, to ensure the commit is named properly when described.
+By default, the `git describe` command requires annotated tags (tags created with the `-a` or `-s` flag); if you want to take advantage of lightweight (non-annotated) tags as well, add the `--tags` option to the command.
 You can also use this string as the target of a `git checkout` or `git show` command, although it relies on the abbreviated SHA-1 value at the end, so it may not be valid forever.
 For instance, the Linux kernel recently jumped from 8 to 10 characters to ensure SHA-1 object uniqueness, so older `git describe` output names were invalidated.
 


### PR DESCRIPTION
Once upon a time, "git describe" worked only with annotated tags;
these days, using "--tags" option allows use of lightweight tags.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>