### PR TITLE
stashing/cleaning: clean up some wording, mention "--all" for stashing

### DIFF
--- a/book/07-git-tools/sections/stashing-cleaning.asc
+++ b/book/07-git-tools/sections/stashing-cleaning.asc
@@ -37,8 +37,8 @@ Changes not staged for commit:
 	modified:   lib/simplegit.rb
 ----
 
-Now you want to switch branches, but you don’t want to commit what you’ve been working on yet; so you’ll stash the changes.
-To push a new stash onto your stack, run `git stash` or `git stash save`:
+Now you want to switch branches, but you don’t want to commit what you’ve been working on yet, so you’ll stash the changes.
+To push a new stash onto your stack, run `git stash` or `git stash push`:
 
 [source,console]
 ----
@@ -69,7 +69,7 @@ stash@{1}: WIP on master: c264051 Revert "added file_size"
 stash@{2}: WIP on master: 21d80a5 added number to log
 ----
 
-In this case, two stashes were done previously, so you have access to three different stashed works.
+In this case, two stashes were saved previously, so you have access to three different stashed works.
 You can reapply the one you just stashed by using the command shown in the help output of the original stash command: `git stash apply`.
 If you want to apply one of the older stashes, you can specify it by naming it, like this: `git stash apply stash@{2}`.
 If you don’t specify a stash, Git assumes the most recent stash and tries to apply it:
@@ -132,7 +132,7 @@ You can also run `git stash pop` to apply the stash and then immediately drop it
 ==== Creative Stashing
 
 There are a few stash variants that may also be helpful.
-The first option that is quite popular is the `--keep-index` option to the `stash save` command.
+The first option that is quite popular is the `--keep-index` option to the `git stash` command.
 This tells Git to not only include all staged content in the stash being created, but simultaneously leave it in the index.
 
 [source,console]
@@ -152,6 +152,7 @@ M  index.html
 Another common thing you may want to do with stash is to stash the untracked files as well as the tracked ones.
 By default, `git stash` will stash only modified and staged _tracked_ files.
 If you specify `--include-untracked` or `-u`, Git will include untracked files in the stash being created.
+However, including untracked files in the stash will still not include explicitly _ignored_ files; to additionally include ignored files, use `--all` (or just `-a`).
 
 [source,console]
 ----
@@ -197,7 +198,7 @@ Saved working directory and index state WIP on master: 1b65b17 added the index f
 
 If you stash some work, leave it there for a while, and continue on the branch from which you stashed the work, you may have a problem reapplying the work.
 If the apply tries to modify a file that you’ve since modified, you’ll get a merge conflict and will have to try to resolve it.
-If you want an easier way to test the stashed changes again, you can run `git stash branch <branch>`, which creates a new branch for you with your selected branch name, checks out the commit you were on when you stashed your work, reapplies your work there, and then drops the stash if it applies successfully:
+If you want an easier way to test the stashed changes again, you can run `git stash branch <new branchname>`, which creates a new branch for you with your selected branch name, checks out the commit you were on when you stashed your work, reapplies your work there, and then drops the stash if it applies successfully:
 
 [source,console]
 ----


### PR DESCRIPTION
A number of minor changes to stashing section, including:

  - emphasize "push" instead of "save"
  - introduce "--all" to include ignored files

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>