### PR TITLE
Small edit to 10.5 Git Internals - The Refspec

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -21,7 +21,7 @@ Running the command above adds a section to your repository's `.git/config` file
 The format of the refspec is, first, an optional `+`, followed by `<src>:<dst>`, where `<src>` is the pattern for references on the remote side and `<dst>` is where those references will be tracked locally.
 The `+` tells Git to update the reference even if it isn't a fast-forward.
 
-In the default case that is automatically written by a `git remote add` command, Git fetches all the references under `refs/heads/` on the server and writes them to `refs/remotes/origin/` locally.
+In the default case that is automatically written by a `git remote add origin` command, Git fetches all the references under `refs/heads/` on the server and writes them to `refs/remotes/origin/` locally.
 So, if there is a `master` branch on the server, you can access the log of that branch locally via any of the following:
 
 [source,console]


### PR DESCRIPTION
The document mentioned that the default behavior of the command `git remote add`  lead to writing the changes locally in `refs/remotes/origin/`. It will be good to make the example command more specific by mentioning `origin` to match the command example with the command result.