### PR TITLE
Added clarification about repo re-initialization

### DIFF
--- a/book/04-git-server/sections/git-on-a-server.asc
+++ b/book/04-git-server/sections/git-on-a-server.asc
@@ -54,7 +54,7 @@ $ git clone user@git.example.com:/srv/git/my_project.git
 
 If a user SSHs into a server and has write access to the `/srv/git/my_project.git` directory, they will also automatically have push access.
 
-Git will automatically add group write permissions to a repository properly if you run the `git init` command with the `--shared` option.(((git commands, init, bare)))
+Git will automatically add group write permissions to a repository properly if you run the `git init` command with the `--shared` option. Note that by running this command, you will not destroy any commits, refs, etc. in the process.(((git commands, init, bare)))
 
 [source,console]
 ----

--- a/book/04-git-server/sections/git-on-a-server.asc
+++ b/book/04-git-server/sections/git-on-a-server.asc
@@ -54,7 +54,8 @@ $ git clone user@git.example.com:/srv/git/my_project.git
 
 If a user SSHs into a server and has write access to the `/srv/git/my_project.git` directory, they will also automatically have push access.
 
-Git will automatically add group write permissions to a repository properly if you run the `git init` command with the `--shared` option. Note that by running this command, you will not destroy any commits, refs, etc. in the process.(((git commands, init, bare)))
+Git will automatically add group write permissions to a repository properly if you run the `git init` command with the `--shared` option. 
+Note that by running this command, you will not destroy any commits, refs, etc. in the process.(((git commands, init, bare)))
 
 [source,console]
 ----


### PR DESCRIPTION
Added a line about running `git init` even after cloning the repo, as it can be unclear that this command is non-destructive.