### PR TITLE
point to the freenode main page

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -17,7 +17,7 @@ $ git help config
 ----
 
 These commands are nice because you can access them anywhere, even offline.
-If the manpages and this book aren't enough and you need in-person help, you can try the `#git` or `#github` channel on the Freenode IRC server (irc.freenode.net).
+If the manpages and this book aren't enough and you need in-person help, you can try the `#git` or `#github` channel on the Freenode IRC server, which can be found at https://freenode.net/[].
 These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.(((IRC)))
 
 In addition, if you don't need the full-blown manpage help, but just need a quick refresher on the available options for a Git command, you can ask for the more concise ``help'' output with the `-h` or `--help` options, as in:


### PR DESCRIPTION
The irc.freenode.net url is repetedly reported to host botnet control - C&C software so it should be removed.
Many(or most) new commers to git are not familiar with IRC so pointing them to freenode's main page might be more helpful since it has some basic info on IRC and a link to the chat url (https://webchat.freenode.net/)

Fixes #1154.