### PR TITLE
Fix usage of sudo to edit file

### DIFF
--- a/book/04-git-server/sections/setting-up-server.asc
+++ b/book/04-git-server/sections/setting-up-server.asc
@@ -97,7 +97,7 @@ To do so, you must first add the full pathname of the `git-shell` command to `/e
 ----
 $ cat /etc/shells   # see if `git-shell` is already in there.  If not...
 $ which git-shell   # make sure git-shell is installed on your system.
-$ sudo vim /etc/shells  # and add the path to git-shell from last command
+$ sudo -e /etc/shells  # and add the path to git-shell from last command
 ----
 
 Now you can edit the shell for a user using `chsh <username> -s <shell>`:


### PR DESCRIPTION
   - vim should not be run as root, but instead use `sudo -e`
     (or sudoedit) which creates a temporary copy of the file
     to edit and then copies it over the original if you modify the
     contents.