### PR TITLE
Undoing things: Clarify what "git checkout" does to local files

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -130,8 +130,8 @@ You can see that the changes have been reverted.
 [IMPORTANT]
 =====
 It's important to understand that `git checkout -- <file>` is a dangerous command.
-Any changes you made to that file are gone -- Git just copied another file over it.
-Don't ever use this command unless you absolutely know that you don't want the file.
+Any local changes you made to that file are gone -- Git just copied the most recently-committed version of that file over top of it.
+Don't ever use this command unless you absolutely know that you don't want those unsaved local changes.
 =====
 
 If you would like to keep the changes you've made to that file but still need to get it out of the way for now, we'll go over stashing and branching in <<ch03-git-branching#ch03-git-branching>>; these are generally better ways to go.


### PR DESCRIPTION
The current explanation of "git checkout -- <file>" seems a bit
vague, so expand on it ever so slightly.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>