### PR TITLE
Changed 'C5' to 'C6' in the rebase example.

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -48,7 +48,7 @@ $ git merge experiment
 .Fast-forwarding the master branch
 image::images/basic-rebase-4.png[Fast-forwarding the master branch.]
 
-Now, the snapshot pointed to by `C4'` is exactly the same as the one that was pointed to by `C5` in the merge example.
+Now, the snapshot pointed to by `C4'` is exactly the same as the one that was pointed to by `C6` in the merge example.
 There is no difference in the end product of the integration, but rebasing makes for a cleaner history.
 If you examine the log of a rebased branch, it looks like a linear history: it appears that all the work happened in series, even when it originally happened in parallel.
 


### PR DESCRIPTION
Looked like by logic there must be 'C6', but not 'C5'.