### PR TITLE
Git version 2.19.1 has new expanded output for git add -h

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -35,12 +35,13 @@ usage: git add [<options>] [--] <pathspec>...
     -e, --edit            edit current diff and apply
     -f, --force           allow adding otherwise ignored files
     -u, --update          update tracked files
+    --renormalize         renormalize EOL of tracked files (implies -u)
     -N, --intent-to-add   record only the fact that the path will be added later
     -A, --all             add changes from all tracked and untracked files
     --ignore-removal      ignore paths removed in the working tree (same as --no-all)
     --refresh             don't add, only refresh the index
     --ignore-errors       just skip files which cannot be added because of errors
     --ignore-missing      check if - even missing - files are ignored in dry run
-    --chmod <(+/-)x>      override the executable bit of the listed files
+    --chmod (+|-)x        override the executable bit of the listed files
 ----
 


### PR DESCRIPTION
@ben Git 2.19.1 on Ubuntu 18.10 has more output when using ``git add -h``.

Is this something you want to merge into master? I don't know what version of git the book is based on?