### PR TITLE
Change README.asc to use https link for the book.

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -2,7 +2,7 @@
 
 Welcome to the second edition of the Pro Git book.
 
-You can find this book online at: http://git-scm.com/book
+You can find this book online at: https://git-scm.com/book
 
 Like the first edition, the second edition of Pro Git is open source under a Creative Commons license.
 


### PR DESCRIPTION
I noticed that the README.asc file still points to a http link instead of a https one. This is fixed with this pull request.