### PR TITLE
Chapter 4 http -> https.

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -68,5 +68,5 @@ You can do this with nearly any CGI-capable web server, so go with the one that 
 
 [NOTE]
 ====
-For more information on configuring authentication in Apache, check out the Apache docs here: http://httpd.apache.org/docs/current/howto/auth.html[]
+For more information on configuring authentication in Apache, check out the Apache docs here: https://httpd.apache.org/docs/current/howto/auth.html[]
 ====


### PR DESCRIPTION
@ben

Onwards to Chapter 4, I'm skipping chapter 2 and 3, because I found no mention of http:// in there.

I only found one relevant link that points to a third party http source. So I've updated that link.

The other mentions were in the gitlab.asc and gitweb.asc files, and those links mention user owned hosted servers (Gitlab or GitWeb), so those can stay in http I think?