### PR TITLE
Chapter 6 http -> https.

### DIFF
--- a/book/06-github/sections/3-maintaining.asc
+++ b/book/06-github/sections/3-maintaining.asc
@@ -89,7 +89,7 @@ You could technically merge in the Pull Request work with something like this:
 
 [source,console]
 ----
-$ curl http://github.com/tonychacon/fade/pull/1.patch | git am
+$ curl https://github.com/tonychacon/fade/pull/1.patch | git am
 ----
 
 ===== Collaborating on the Pull Request

--- a/book/06-github/sections/5-scripting.asc
+++ b/book/06-github/sections/5-scripting.asc
@@ -159,7 +159,7 @@ $ curl https://api.github.com/gitignore/templates/Java
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 "
 }
@@ -296,7 +296,7 @@ This is really useful if you're using this API for test results so you don't acc
 
 Though we've been doing nearly everything through `curl` and simple HTTP requests in these examples, several open-source libraries exist that make this API available in a more idiomatic way.
 At the time of this writing, the supported languages include Go, Objective-C, Ruby, and .NET.
-Check out http://github.com/octokit[] for more information on these, as they handle much of the HTTP for you.
+Check out https://github.com/octokit[] for more information on these, as they handle much of the HTTP for you.
 
 Hopefully these tools can help you customize and modify GitHub to work better for your specific workflows.
 For complete documentation on the entire API as well as guides for common tasks, check out https://developer.github.com[].


### PR DESCRIPTION
@ben

Regarding book/06-github/sections/3-maintaining.asc:

According to the curl documentation, curl can use https now, so this should work I think. But I don't use curl, so I don't know if this breaks the example.

---

Regarding  book/06-github/sections/5-scripting.asc:

The changes are quite simple here, java uses https for their website, as does github. So I've changed those links.