### PR TITLE
Chapter 8 http -> https.

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -63,7 +63,7 @@ What is the ``word'' filter?
 You have to set it up.
 Here you'll configure Git to use the `docx2txt` program to convert Word documents into readable text files, which it will then diff properly.
 
-First, you'll need to install `docx2txt`; you can download it from http://docx2txt.sourceforge.net[].
+First, you'll need to install `docx2txt`; you can download it from https://sourceforge.net/projects/docx2txt[].
 Follow the instructions in the `INSTALL` file to put it somewhere your shell can find it.
 Next, you'll write a wrapper script to convert output to the format Git expects.
 Create a file that's somewhere in your path called `docx2txt`, and add these contents:

--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -45,7 +45,7 @@ $ man git-config
 ----
 
 This command lists all the available options in quite a bit of detail.
-You can also find this reference material at http://git-scm.com/docs/git-config.html[].
+You can also find this reference material at https://git-scm.com/docs/git-config[].
 
 ===== `core.editor`
 


### PR DESCRIPTION
@ben 

I'm skipping chapter 7, I found no http:// links there.

I found a http:// link at book/08-customizing-git/sections/attributes.asc:
>First, you'll need to install `docx2txt`; you can download it from http://docx2txt.sourceforge.net[].

I'm not sure if this should be replaced or not. I've found this: https://sourceforge.net/projects/docx2txt/ but I don't know if that is the proper replacement for it...