### PR TITLE
Chapter 9 http -> https. 

### DIFF
--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -1,7 +1,7 @@
 ==== Git and Bazaar
 
-Among the DVCS, another famous one is http://bazaar.canonical.com/[Bazaar].
-Bazaar is free and open source, and is part of the https://www.gnu.org/[GNU Project].
+Among the DVCS, another famous one is http://bazaar.canonical.com[Bazaar].
+Bazaar is free and open source, and is part of the https://www.gnu.org[GNU Project].
 It behaves very differently from Git.
 Sometimes, to do the same thing as with Git, you have to use a different keyword, and some keywords that are common don't have the same meaning.
 In particular, the branch management is very different and may cause confusion, especially when someone comes from Git's universe.

--- a/book/09-git-and-other-scms/sections/client-bzr.asc
+++ b/book/09-git-and-other-scms/sections/client-bzr.asc
@@ -1,7 +1,7 @@
 ==== Git and Bazaar
 
 Among the DVCS, another famous one is http://bazaar.canonical.com/[Bazaar].
-Bazaar is free and open source, and is part of the http://www.gnu.org/[GNU Project].
+Bazaar is free and open source, and is part of the https://www.gnu.org/[GNU Project].
 It behaves very differently from Git.
 Sometimes, to do the same thing as with Git, you have to use a different keyword, and some keywords that are common don't have the same meaning.
 In particular, the branch management is very different and may cause confusion, especially when someone comes from Git's universe.

--- a/book/09-git-and-other-scms/sections/client-tfs.asc
+++ b/book/09-git-and-other-scms/sections/client-tfs.asc
@@ -31,7 +31,7 @@ We'll cover the basic usage of both of them in this book.
 ====
 You'll need access to a TFVC-based repository to follow along with these instructions.
 These aren't as plentiful in the wild as Git or Subversion repositories, so you may need to create one of your own.
-Codeplex (https://www.codeplex.com[]) or Visual Studio Online (http://www.visualstudio.com[]) are both good choices for this.
+Codeplex (https://www.codeplex.com[]) or Visual Studio Online (https://visualstudio.microsoft.com[]) are both good choices for this.
 ====
 
 


### PR DESCRIPTION
@ben My observations while fixing chapter 9:

---

client-bzr.asc:
Bazaar still uses http:// for their website...

---

client-hg.asc:
Mercurial still links to the http selenic repo when cloning, this is even mentioned in their own wiki, so this can stay.

---

client-p4.asc:
I don't know anything about perforce, so I'm not touching things here.
https://www.perforce.com/products doesn't list Git Fusion anymore, is this still relevant? Git Fusion is not EOL, as can be seen here: https://www.perforce.com/maintenance-support#eol_schedule

---

client-svn.asc:
I don't know anything about Subversion, so I'm not touching things here.

---

client-tfs.asc:
Changed Visual Studio link.

---

import-svn.asc:
I don't know anything about Subversion, so I'm not touching things here.

---