### PR TITLE
contributing.md has outdated link which redirects to new domain.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Professional copy editors have already reviewed this content multiple times so w
 
 ## Figures
 
-The images in this book were generated using [Sketch 3](http://bohemiancoding.com/sketch/), with the [included sketchbook file](diagram-source/progit.sketch).
+The images in this book were generated using [Sketch 3](https://www.sketchapp.com/), with the [included sketchbook file](diagram-source/progit.sketch).
 
 To add a figure:
 


### PR DESCRIPTION
This link is outdated, using it redirects to the new domain: https://www.sketchapp.com/

By the way, it appears Sketch is now on version 52, according to https://www.sketchapp.com/