### PR TITLE
Reinstate Beyond Pro Git section.

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -88,3 +88,15 @@ Copy that file, and put it in your working directory. Commit the .yml file and p
 ## Setting up a publication chain for e-books
 
 This is a technical task, please ping @jnavila to get started with epub publication.
+
+## Beyond Pro Git
+
+Translating the book is the first step. Once this is finished, you could consider translating the user interface of Git itself.
+
+This task requires a more technical knowledge of the tool than the book. Hopefully, after having translated the full book content, you can understand the terms used in the application. If you feel technically up to the task, the repo is [here](https://github.com/git-l10n/git-po) and you just have to follow the [guide](https://github.com/git-l10n/git-po/blob/master/po/README).
+
+Beware though that
+
+ * you'll need to use more specific tools to manage localization po files (such as editing them with [poedit](https://poedit.net/) and merging them. You might need to compile git in order to check your work.
+ * a basic knowledge of how translating applications works is required, which is significantly different from translating books.
+ * the core Git project uses more stringent [procedures](https://github.com/git-l10n/git-po/blob/master/Documentation/SubmittingPatches) to accept contributions, be sure to abide by them.


### PR DESCRIPTION
@jnavila @ben

I've reinstated the old section about "Beyond Pro Git" to the end of the file.

Sequence of events:
* Made a new branch based on master
* ``git checkout 039fe2a934ae19b7d0c45599fc8662c588de9b61``
* Opened translating.md
* Manually copy the section Beyond Pro Git
* Made a new branch to rollback based on master
* Manually pasted the Beyond Pro Git section into master/translating.md

I think/know that this way is probably not the best way of rolling things back (essentially I just manually undid the work).

Also I'm not sure what you're supposed to do once changes are merged into master, I know not to use git --rebase on things that you've pushed, because that annoys everybody, because you re-write history under their feet?

I'm not sure how this rollback could be done cleaner. There seem to be 3 versions of reset, and also you can use ``checkout **specific commit sha1 id**``, so I'm getting quite confused. :worried: 

So I'm also looking for a bit of advice on how to do this properly and not in a hacky quick-fix way... :smile: 

For reference: #1229