### PR TITLE
Add Thai translation project to TRANSLATING.md

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -41,6 +41,7 @@ The following are guidelines to help you on your way:
 | Русский   | [progit/progit2-ru](https://github.com/progit/progit2-ru) |
 | Slovenščina  | [progit/progit2-sl](https://github.com/progit/progit2-sl) |
 | Српски   | [progit/progit2-sr](https://github.com/progit/progit2-sr) |
+| ไทย | [progit2-th](https://github.com/progit2-th/progit2) |
 | Tagalog   | [progit2-tl/progit2](https://github.com/progit2-tl/progit2) |
 | Türkçe   | [progit/progit2-tr](https://github.com/progit/progit2-tr) |
 | Українська| [progit/progit2-uk](https://github.com/progit/progit2-uk) |


### PR DESCRIPTION
While getting issue #361 closed, I noticed the Thai translation is not yet mentioned in the TRANSLATING.md file. This fixes that.

@jnavila can you check my work here? I hope I got the right organization here. :smile: