### PR TITLE
Remove ubuntu 14.04 and upstart.

### DIFF
--- a/book/04-git-server/sections/git-daemon.asc
+++ b/book/04-git-server/sections/git-daemon.asc
@@ -52,40 +52,6 @@ Also, check that the Git binary is indeed located at `/usr/bin/git` and change t
 
 Finally, you'll run `systemctl enable git-daemon` to automatically start the service on boot, and can start and stop the service with, respectively, `systemctl start git-daemon` and `systemctl stop git-daemon`.
 
-Up to and including LTS 14.04, Ubuntu used upstart service unit configuration.
-Therefore, on Ubuntu 14.04 or earlier, you can use an Upstart script.
-So, in the following file
-
-[source,console]
-----
-/etc/init/local-git-daemon.conf
-----
-
-you put this script:
-
-[source,console]
-----
-start on startup
-stop on shutdown
-exec /usr/bin/git daemon \
-    --user=git --group=git \
-    --reuseaddr \
-    --base-path=/srv/git/ \
-    /srv/git/
-respawn
-----
-
-For security reasons, it is strongly encouraged to have this daemon run as a user with read-only permissions to the repositories -- you can easily do this by creating a new user 'git-ro' and running the daemon as them.
-For the sake of simplicity we'll simply run it as the same 'git' user that `git-shell` is running as.
-
-When you restart your machine, your Git daemon will start automatically and respawn if it goes down.
-To get it running without having to reboot, you can run this:
-
-[source,console]
-----
-$ initctl start local-git-daemon
-----
-
 On other systems, you may want to use `xinetd`, a script in your `sysvinit` system, or something else -- as long as you get that command daemonized and watched somehow.
 
 Next, you have to tell Git which repositories to allow unauthenticated Git server-based access to.


### PR DESCRIPTION
Ubuntu 14.04 reaches End of Life this month, upstart is also old. (See: https://www.ubuntu.com/about/release-cycle)

I'm not sure about the:
>On other systems, you may want to use `xinetd`, a script in your `sysvinit` system, or something else -- as long as you get that command daemonized and watched somehow.

section so I'm leaving that in.