### PR TITLE
Add a bug report template. (DO NOT MERGE)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,8 @@ assignees: ''
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
-**This bug affects:**
-<!--  Is this bug about the pdf, or the [website](https://www.git-scm.com/book/en/v2)?-->
+**What version of the book is affected?**
+<!--  Is this bug about the pdf or the [online book](https://www.git-scm.com/book/en/v2), or both?-->
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,6 @@ assignees: ''
 - This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf.
 - If you found a issue in the pdf, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
 - This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- This bug is **not** about the .epub or .mobi files.
 - This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **I confirm:**
-<!-- To mark a task as complete, use ```[x]``` -->
+<!-- To mark a task as complete, use [x] -->
 - [ ] that I haven't found an existing/similar bug report for my bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,6 @@ To mark a task as complete, use ```[x]```
  - Browser: <!-- [e.g. stock browser, safari] -->
  - Version: <!-- [e.g. 22] -->
 
-**Additional context**
+**Additional context:**
 <!-- Add any other context about the problem here. -->
 <!-- You can also put references to similar bugs here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,18 +44,21 @@ assignees: ''
 
 **Desktop:**
 <!-- If you've used a desktop/laptop to access the content, please fill in this form. -->
-- OS: <!--[iOS] -->
-- Browser/application: <!-- [chrome, safari, Evince, Adobe Acrobat Reader] -->
-- Version: <!-- [22] -->
+<!-- Example: Windows 10 Home Edition, Firefox, version 66.0.2 -->
+- Operating system:
+- Browser/application:
+- Browser/application version:
 
 **Smartphone:**
 <!-- If you've used a smartphone to access the content, please fill in this form. -->
-- Device: <!-- [iPhone6] -->
-- OS: <!-- [iOS8.1] -->
-- Browser/application: <!-- [stock browser, safari, Adobe Acrobat Reader] -->
-- Version: <!-- [22] -->
+<!-- Example: iPhone 6, iOS 12.2, Safari, version 22 -->
+- Device:
+- OS:
+- Browser/application:
+- Browser/application version:
 
 **E-book reader:**
 <!-- If you've used a e-book reader to access the content, please fill in this form. -->
-- Device: <!-- [Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
-- Software Update: <!-- [version 5.11.1 for Amazon Kindle] -->
+<!-- Example: Amazon Kindle Paperwhite 10th generation, software update 5.11.1 -->
+- Device:
+- Software Update:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,9 +19,7 @@ assignees: ''
 - this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **This bug report is about:**
-<!--  Use [x] to mark the check-box. -->
-- [ ] the pdf.
-- [ ] the Pro Git 2 book on the [website](https://www.git-scm.com/book/en/v2).
+<!--  Is this bug about the pdf, or the [website](https://www.git-scm.com/book/en/v2)?-->
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,8 @@ assignees: ''
 
 **I confirm:**
 <!-- To mark a task as complete, use [x] -->
-- [ ] that I haven't found an existing/similar bug report for my bug.
+- [ ] I haven't found an existing/similar bug report for my bug.
+- [ ] this bug report is about a single actionable bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
 - [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,8 @@ assignees: ''
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
+---
+
 **Which version of the book is affected?**
 <!-- It's important for us to know if the problem is in the source or in the tooling for the pdf/epub/mobi files. -->
 <!-- Therefore, please write whether the problem is with the files, the online book, or both. -->
@@ -38,6 +40,12 @@ assignees: ''
 **Screenshots**
 <!-- If applicable, add screenshots to help explain your problem. -->
 
+**Additional context:**
+<!-- Add any other context about the problem here. -->
+<!-- You can also put references to similar bugs here. -->
+
+---
+
 **Desktop:**
 <!-- If you've used a desktop/laptop to access the content, please fill in this form. -->
 - OS: <!--[e.g. iOS] -->
@@ -55,7 +63,3 @@ assignees: ''
 <!-- If you've used a e-book reader to access the content, please fill in this form. -->
 - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
 - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
-
-**Additional context:**
-<!-- Add any other context about the problem here. -->
-<!-- You can also put references to similar bugs here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,17 +39,20 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Desktop:**
+<!-- If you've used a desktop/laptop to access the content, please fill in this form. -->
 - OS: <!--[e.g. iOS] -->
 - Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
 - Version: <!-- [e.g. 22] -->
 
 **Smartphone:**
+<!-- If you've used a smartphone to access the content, please fill in this form. -->
 - Device: <!-- [e.g. iPhone6] -->
 - OS: <!-- [e.g. iOS8.1] -->
 - Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
 - Version: <!-- [e.g. 22] -->
 
 **E-book reader:**
+<!-- If you've used a e-book reader to access the content, please fill in this form. -->
 - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
 - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ assignees: ''
 
 **Desktop (please complete the following information):**
  - OS: <!--[e.g. iOS] -->
- - Browser: <!-- [e.g. chrome, safari] -->
+ - Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
  - Version: <!-- [e.g. 22] -->
 
 **Smartphone (please complete the following information):**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,17 +7,16 @@ assignees: ''
 
 ---
 
-**I confirm:**
-<!--  Use [x] to mark the check-box. -->
-- [ ] I haven't found an existing/similar bug report for my bug.
-- [ ] this bug report is about a single actionable bug.
-- [ ] if this issue has been spotted in the pdf, I've checked that the problem is also present on the [website](https://www.git-scm.com/book/en/v2)
-- [ ] this bug is about the second version of the Git Pro book in English, as found on https://www.git-scm.com/book/en/v2 or the pdf.
-- [ ] this bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- [ ] this bug is **not** about .epub or .mobi files.
-- [ ] this bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
-- [ ] this bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
-- [ ] this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
+**Before filing a bug check the following:**
+- I haven't found an existing/similar bug report for my bug.
+- this bug report is about a single actionable bug.
+- if this issue has been spotted in the pdf, I've checked that the problem is also present on the [website](https://www.git-scm.com/book/en/v2)
+- this bug is about the second version of the Git Pro book in English, as found on https://www.git-scm.com/book/en/v2 or the pdf.
+- this bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
+- this bug is **not** about .epub or .mobi files.
+- this bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
+- this bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
+- this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **This bug report is about:**
 <!--  Use [x] to mark the check-box. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,8 +42,6 @@ assignees: ''
 <!-- Add any other context about the problem here. -->
 <!-- You can also put references to similar bugs here. -->
 
----
-
 **Desktop:**
 <!-- If you've used a desktop/laptop to access the content, please fill in this form. -->
 - OS: <!--[e.g. iOS] -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,7 @@ assignees: ''
 ---
 
 **I confirm:**
+To mark a task as complete, use ```[x]```
 - [ ] that I haven't found an existing/similar bug report for my bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+**I confirm:**
+- [ ] that I haven't found an existing/similar bug report for my bug.
+- [ ] If this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
+- [ ] this bug is about the second version of the Git Pro book in English.
+- [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
+- [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)
+- [ ] This bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,7 @@ assignees: ''
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
+<!-- Please write the steps needed to reproduce the bug here. -->
 <!-- 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ assignees: ''
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
 - [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
 - [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)
-- [ ] This bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
+- [ ] this bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,8 +18,9 @@ assignees: ''
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
-**What version of the book is affected?**
-<!--  Is this bug about the pdf or the [online book](https://www.git-scm.com/book/en/v2), or both?-->
+**Which version of the book is affected?**
+<!-- It's important for us to know if the problem is in the source or in the tooling for the pdf/epub/mobi files. -->
+<!-- Therefore, please write whether the problem is with the files, the online book, or both. -->
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **I confirm:**
-To mark a task as complete, use ```[x]```
+<!-- To mark a task as complete, use ```[x]``` -->
 - [ ] that I haven't found an existing/similar bug report for my bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 <!--  Use [x] to mark the check-box. -->
 - [ ] I haven't found an existing/similar bug report for my bug.
 - [ ] this bug report is about a single actionable bug.
-- [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
+- [ ] if this issue has been spotted in the pdf, I've checked that the problem is also present on the [website](https://www.git-scm.com/book/en/v2)
 - [ ] this bug is about the second version of the Git Pro book in English, as found on https://www.git-scm.com/book/en/v2 or the pdf.
 - [ ] this bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
 - [ ] this bug is **not** about .epub or .mobi files.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,7 +51,7 @@ assignees: ''
  - Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
  - Version: <!-- [e.g. 22] -->
 
- **E-book reader:**
+**E-book reader:**
  - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
  - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,18 +7,16 @@ assignees: ''
 
 ---
 
-**Before filing a bug please check the following:**
-- There's no existing/similar bug report.
-- This bug report is about a single actionable bug.
-- This bug is about the Pro Git book, version 2, English language.
-- This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf.
-- If you found a issue in the pdf/epub/mobi files, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
-- This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
-- This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
-- This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
-
----
+<!-- Before filing a bug please check the following: -->
+<!-- * There's no existing/similar bug report. -->
+<!-- * This bug report is about a single actionable bug. -->
+<!-- * This bug is about the Pro Git book, version 2, English language. -->
+<!-- * This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf. -->
+<!-- * If you found a issue in the pdf/epub/mobi files, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2). -->
+<!-- * This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md) -->
+<!-- * This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new) -->
+<!-- * This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community) -->
+<!-- * This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git). -->
 
 **Which version of the book is affected?**
 <!-- It's important for us to know if the problem is in the source or in the tooling for the pdf/epub/mobi files. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,7 +43,7 @@ assignees: ''
 **Smartphone (please complete the following information):**
  - Device: <!-- [e.g. iPhone6] -->
  - OS: <!-- [e.g. iOS8.1] -->
- - Browser: <!-- [e.g. stock browser, safari] -->
+ - Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
  - Version: <!-- [e.g. 22] -->
 
  **E-book reader:**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 **I confirm:**
 - [ ] that I haven't found an existing/similar bug report for my bug.
 - [ ] If this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
-- [ ] this bug is about the second version of the Git Pro book in English.
+- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a list of those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
 - [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
 - [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)
 - [ ] This bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,10 +21,10 @@ To mark a task as complete, use ```[x]```
 
 **Steps to reproduce:**
 <!-- Please write the steps needed to reproduce the bug here. -->
-<!-- 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error -->
+<!-- 1. Go to '...' -->
+<!-- 2. Click on '....' -->
+<!-- 3. Scroll down to '....' -->
+<!-- 4. See error -->
 
 **Expected behavior**
 <!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,18 +7,19 @@ assignees: ''
 
 ---
 
-**Before filing a bug check the following:**
-- I haven't found an existing/similar bug report for my bug.
-- this bug report is about a single actionable bug.
-- if this issue has been spotted in the pdf, I've checked that the problem is also present on the [website](https://www.git-scm.com/book/en/v2)
-- this bug is about the second version of the Git Pro book in English, as found on https://www.git-scm.com/book/en/v2 or the pdf.
-- this bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- this bug is **not** about .epub or .mobi files.
-- this bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
-- this bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
-- this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
+**Before filing a bug please check the following:**
+- There's no existing/similar bug report.
+- This bug report is about a single actionable bug.
+- This bug is about the Pro Git book, version 2, English language.
+- This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf.
+- If you found a issue in the pdf, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
+- This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
+- This bug is **not** about .epub or .mobi files.
+- This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
+- This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
+- This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
-**This bug report is about:**
+**This bug affects:**
 <!--  Is this bug about the pdf, or the [website](https://www.git-scm.com/book/en/v2)?-->
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,7 +48,7 @@ assignees: ''
 
  **E-book reader:**
  - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
- - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle]
+ - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
 
 **Additional context:**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,6 +44,10 @@ assignees: ''
  - Browser: <!-- [e.g. stock browser, safari] -->
  - Version: <!-- [e.g. 22] -->
 
+ **E-book reader:**
+ - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
+ - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle]
+
 **Additional context:**
 <!-- Add any other context about the problem here. -->
 <!-- You can also put references to similar bugs here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ assignees: ''
 <!-- It's important for us to know if the problem is in the source or in the tooling for the pdf/epub/mobi files. -->
 <!-- Therefore, please write whether the problem is with the files, the online book, or both. -->
 
-**Describe the bug**
+**Describe the bug:**
 <!-- A clear and concise description of what the bug is. -->
 
 **Steps to reproduce:**
@@ -32,10 +32,10 @@ assignees: ''
 <!-- 3. Scroll down to '....' -->
 <!-- 4. See error -->
 
-**Expected behavior**
+**Expected behavior:**
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots**
+**Screenshots:**
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context:**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,10 +12,12 @@ assignees: ''
 - [ ] I haven't found an existing/similar bug report for my bug.
 - [ ] this bug report is about a single actionable bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
-- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- [ ] this bug is not about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
-- [ ] this bug is not about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
-- [ ] this bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
+- [ ] this bug is about the second version of the Git Pro book in English, as found on https://www.git-scm.com/book/en/v2 or the pdf.
+- [ ] this bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
+- [ ] this bug is **not** about .epub or .mobi files.
+- [ ] this bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
+- [ ] this bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
+- [ ] this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **I confirm:**
 - [ ] that I haven't found an existing/similar bug report for my bug.
-- [ ] If this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
+- [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
 - [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
 - [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
 - [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,12 +40,12 @@ assignees: ''
 **Screenshots**
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
+**Desktop:**
  - OS: <!--[e.g. iOS] -->
  - Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
  - Version: <!-- [e.g. 22] -->
 
-**Smartphone (please complete the following information):**
+**Smartphone:**
  - Device: <!-- [e.g. iPhone6] -->
  - OS: <!-- [e.g. iOS8.1] -->
  - Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,9 +12,9 @@ assignees: ''
 - [ ] I haven't found an existing/similar bug report for my bug.
 - [ ] this bug report is about a single actionable bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
-- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
-- [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
-- [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)
+- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
+- [ ] this bug is not about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
+- [ ] this bug is not about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - [ ] this bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,31 +16,30 @@ assignees: ''
 - [ ] This bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
+<!-- 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+ - OS: <!--[e.g. iOS] -->
+ - Browser: <!-- [e.g. chrome, safari] -->
+ - Version: <!-- [e.g. 22] -->
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+ - Device: <!-- [e.g. iPhone6] -->
+ - OS: <!-- [e.g. iOS8.1] -->
+ - Browser: <!-- [e.g. stock browser, safari] -->
+ - Version: <!-- [e.g. 22] -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 - This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf.
 - If you found a issue in the pdf, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
 - This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
-- This bug is **not** about .epub or .mobi files.
+- This bug is **not** about the .epub or .mobi files.
 - This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 **I confirm:**
 - [ ] that I haven't found an existing/similar bug report for my bug.
 - [ ] If this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
-- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a list of those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
+- [ ] this bug is about the second version of the Git Pro book in English. A bug for a translation should be filed with the translation project. You can find a table with those projects here: https://github.com/progit/progit2/blob/master/TRANSLATING.md
 - [ ] this bug is not about the git-scm.com site, if so please file a bug here: https://github.com/git/git-scm.com/issues/new
 - [ ] this bug is not about git the program itself, if so please file a bug here: [community](https://git-scm.com/community)
 - [ ] This bug is not about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,11 @@ assignees: ''
 - [ ] this bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)
 - [ ] this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
+**This bug report is about:**
+<!--  Use [x] to mark a box. -->
+- [ ] the pdf.
+- [ ] the Pro Git 2 book on the [website](https://www.git-scm.com/book/en/v2).
+
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ assignees: ''
 - This bug report is about a single actionable bug.
 - This bug is about the Pro Git book, version 2, English language.
 - This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf.
-- If you found a issue in the pdf, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
+- If you found a issue in the pdf/epub/mobi files, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2).
 - This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md)
 - This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new)
 - This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ To mark a task as complete, use ```[x]```
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
+**Steps to reproduce:**
 <!-- Please write the steps needed to reproduce the bug here. -->
 <!-- 1. Go to '...'
 2. Click on '....'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **I confirm:**
-<!-- To mark a task as complete, use [x] -->
+<!--  Use [x] to mark the check-box. -->
 - [ ] I haven't found an existing/similar bug report for my bug.
 - [ ] this bug report is about a single actionable bug.
 - [ ] if this issue has been spotted on the git-scm.com site, I've cross-checked that my issue is still present in the current pdf version.
@@ -20,7 +20,7 @@ assignees: ''
 - [ ] this bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git).
 
 **This bug report is about:**
-<!--  Use [x] to mark a box. -->
+<!--  Use [x] to mark the check-box. -->
 - [ ] the pdf.
 - [ ] the Pro Git 2 book on the [website](https://www.git-scm.com/book/en/v2).
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,3 +44,4 @@ assignees: ''
 
 **Additional context**
 <!-- Add any other context about the problem here. -->
+<!-- You can also put references to similar bugs here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,18 +44,18 @@ assignees: ''
 
 **Desktop:**
 <!-- If you've used a desktop/laptop to access the content, please fill in this form. -->
-- OS: <!--[e.g. iOS] -->
-- Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
-- Version: <!-- [e.g. 22] -->
+- OS: <!--[iOS] -->
+- Browser/application: <!-- [chrome, safari, Evince, Adobe Acrobat Reader] -->
+- Version: <!-- [22] -->
 
 **Smartphone:**
 <!-- If you've used a smartphone to access the content, please fill in this form. -->
-- Device: <!-- [e.g. iPhone6] -->
-- OS: <!-- [e.g. iOS8.1] -->
-- Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
-- Version: <!-- [e.g. 22] -->
+- Device: <!-- [iPhone6] -->
+- OS: <!-- [iOS8.1] -->
+- Browser/application: <!-- [stock browser, safari, Adobe Acrobat Reader] -->
+- Version: <!-- [22] -->
 
 **E-book reader:**
 <!-- If you've used a e-book reader to access the content, please fill in this form. -->
-- Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
-- Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
+- Device: <!-- [Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
+- Software Update: <!-- [version 5.11.1 for Amazon Kindle] -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,19 +41,19 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Desktop:**
- - OS: <!--[e.g. iOS] -->
- - Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
- - Version: <!-- [e.g. 22] -->
+- OS: <!--[e.g. iOS] -->
+- Browser/application: <!-- [e.g. chrome, safari, Evince, Adobe Acrobat Reader] -->
+- Version: <!-- [e.g. 22] -->
 
 **Smartphone:**
- - Device: <!-- [e.g. iPhone6] -->
- - OS: <!-- [e.g. iOS8.1] -->
- - Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
- - Version: <!-- [e.g. 22] -->
+- Device: <!-- [e.g. iPhone6] -->
+- OS: <!-- [e.g. iOS8.1] -->
+- Browser/application: <!-- [e.g. stock browser, safari, Adobe Acrobat Reader] -->
+- Version: <!-- [e.g. 22] -->
 
 **E-book reader:**
- - Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
- - Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
+- Device: <!-- [e.g. Amazon Kindle Paperwhite 10th generation, Kobo Clara HD] -->
+- Software Update: <!-- [e.g. version 5.11.1 for Amazon Kindle] -->
 
 **Additional context:**
 <!-- Add any other context about the problem here. -->


### PR DESCRIPTION
:construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: 

Hi @ben, @schacon, @jnavila,

I think that there is a lot to be gained by adopting templates for bugs/features/pull-requests.
I'll explain why I think this is a good idea below.

I think helping contribute to a project should be easy and clear. Templates are a good way to achieve this. A template can have helpful guidance and a checklist of common pitfalls/errors. If contributors follow the checklist, and follow the template, they should end up with a good bug report/feature request/pull request. This takes the guesswork out of contributing.

During my efforts to clean up the old issues on the issue tracker, I've noticed that sometimes people file multiple bugs in one bug report. This makes it hard to diagnose/track the issue(s). A bug report should have a single actionable bug. That way it's easy to track, fix and close.

We should also remind people not to file a duplicate bug, or file the bug in the wrong place, I've added a checklist that people can mark with x to show they checked it. This will also reduce the frustration of making a good effort attempt, only to find out later that you've filed the bug in the wrong place, or made a duplicate and it gets closed.

---

Below is a starting point for a bug report template. This is work in progress, and is open to feedback.

I hope you all find this helpful. If not, feel free to say so, and I'll leave it be. :+1: 

:construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: 