### PR TITLE
Reword sentence about losing local changes

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -130,7 +130,7 @@ You can see that the changes have been reverted.
 [IMPORTANT]
 =====
 It's important to understand that `git checkout -- <file>` is a dangerous command.
-Any local changes you made to that file are gone -- Git just copied the most recently-committed version of that file over top of it.
+Any local changes you made to that file are gone -- Git just replaced that file with the most recently-committed version.
 Don't ever use this command unless you absolutely know that you don't want those unsaved local changes.
 =====
 


### PR DESCRIPTION
1. Avoid awkward idiom, as discussed in https://github.com/progit/progit2/pull/1179#issuecomment-468422175.
2. Fix pronoun: As it was written, 'it' would've referred to the subject of the sentence, 'changes'. Besides the singular-plural disagreement, it should've said the _file_ was replaced, not the changes.