### PR TITLE
Reduce redundancy in story description

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -156,7 +156,7 @@ The basic format is `<oldref>..<newref> fromref -> toref`, where `oldref` means 
 You'll see similar output like this below in the discussions, so having a basic idea of the meaning will help in understanding the various states of the repositories.
 More details are available in the documentation for https://git-scm.com/docs/git-push[git-push].
 
-Continuing with this example, shortly afterwards, John makes some changes, commits them to his local repository, and tries to push them to the same server:
+Continuing with this example, shortly afterwards, John tries to push them to the same server:
 
 [source,console]
 ----


### PR DESCRIPTION
Prior to this fix the description insinuates John had made two commits
in this process phase. Please compare with elaborations shortly
before first transcript for John's machine.