### PR TITLE
Fix: Inspecting commits made on topic branch since...

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -282,7 +282,7 @@ or, more concisely:
 $ git diff $(git merge-base contrib master)
 ----
 
-However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the ellipsis (double-dot) syntax.
+However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the double-dot syntax.
 In the context of the `git diff` command, you can put two periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
 
 [source,console]

--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -282,12 +282,12 @@ or, more concisely:
 $ git diff $(git merge-base contrib master)
 ----
 
-However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the triple-dot syntax.
-In the context of the `git diff` command, you can put three periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
+However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the ellipsis (double-dot) syntax.
+In the context of the `git diff` command, you can put two periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
 
 [source,console]
 ----
-$ git diff master...contrib
+$ git diff master..contrib
 ----
 
 This command shows you only the work your current topic branch has introduced since its common ancestor with master.


### PR DESCRIPTION
common ancestor with main branch.

Issue detected and fixed by consulting git-revisions manual page
(used git version is 2.21.0):
 <rev1>...<rev2> - Include commits that are reachable from either <rev1> or <rev2>
 but exclude those that are reachable from both...
 <rev1>..<rev2> - Include commits that are reachable from <rev2>
 but exclude those that are reachable from <rev1>...