### PR TITLE
Add extra notes about format for a commit object

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -271,7 +271,7 @@ committer Scott Chacon <schacon@gmail.com> 1243040974 -0700
 first commit
 ----
 
-The format for a commit object is simple: it specifies the top-level tree for the snapshot of the project at that point; the author/committer information (which uses your `user.name` and `user.email` configuration settings and a timestamp); a blank line, and then the commit message.
+The format for a commit object is simple: it specifies the top-level tree for the snapshot of the project at that point; the parent commits if any (the commit object described above does not have any parents); the author/committer information (which uses your `user.name` and `user.email` configuration settings and a timestamp); a blank line, and then the commit message.
 
 Next, you'll write the other two commit objects, each referencing the commit that came directly before it:
 


### PR DESCRIPTION
From my point of view we should note here that a commit object
contains its parent commit(s)