### PR TITLE
Extend the git commands list to get the manpage

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -6,6 +6,7 @@ If you ever need help while using Git, there are two equivalent ways to get the 
 [source,console]
 ----
 $ git help <verb>
+$ git <verb> --help
 $ man git-<verb>
 ----
 


### PR DESCRIPTION
Recently I found the extra way to get the manpage so I'd like add it
to the book.