### PR TITLE
Note about moving the branch after a commit

### DIFF
--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -113,7 +113,7 @@ $ vim test.rb
 $ git commit -a -m 'made a change'
 ----
 
-.The HEAD branch moves forward when a commit is made
+.The testing branch moves forward when a commit is made, The HEAD still points to the testing branch
 image::images/advance-testing.png[The HEAD branch moves forward when a commit is made.]
 
 This is interesting, because now your `testing` branch has moved forward, but your `master` branch still points to the commit you were on when you ran `git checkout` to switch branches.


### PR DESCRIPTION
Actually the branch pointer moves after a commit, but not the HEAD in
this case. The HEAD still points to the branch.

So the branch pointer has moved only.