### PR TITLE
Simplify the way to get own branch from remote

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -115,12 +115,12 @@ It's important to note that when you do a fetch that brings down new remote-trac
 In other words, in this case, you don't have a new `serverfix` branch -- you have only an `origin/serverfix` pointer that you can't modify.
 
 To merge this work into your current working branch, you can run `git merge origin/serverfix`.
-If you want your own `serverfix` branch that you can work on, you can base it off your remote-tracking branch:
+If you want your own `serverfix` branch that you can work on, you can simply checkout to `serverfix` branch (which is not existed yet):
 
 [source,console]
 ----
-$ git checkout -b serverfix origin/serverfix
-Branch serverfix set up to track remote branch serverfix from origin.
+$ git checkout serverfix
+Branch 'serverfix' set up to track remote branch 'serverfix' from 'origin'.
 Switched to a new branch 'serverfix'
 ----
 


### PR DESCRIPTION
I'm not sure about older versions of Git, but my local Git version
(2.21.0) supports this way to automatically create local branch from
the remote one and checkout to it at the same time.

So I'd like to suggest this way to do that.