### PR TITLE
Revert Pull Request #1252

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -282,12 +282,12 @@ or, more concisely:
 $ git diff $(git merge-base contrib master)
 ----
 
-However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the double-dot syntax.
-In the context of the `git diff` command, you can put two periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
+However, neither of those is particularly convenient, so Git provides another shorthand for doing the same thing: the triple-dot syntax.
+In the context of the `git diff` command, you can put three periods after another branch to do a `diff` between the last commit of the branch you're on and its common ancestor with another branch:
 
 [source,console]
 ----
-$ git diff master..contrib
+$ git diff master...contrib
 ----
 
 This command shows you only the work your current topic branch has introduced since its common ancestor with master.


### PR DESCRIPTION
Reverts #1252

Previous text (c5689622683df636c92a6138fd0c4c6e45bdc2fe) was correct.

The pull request being reverted applies the meaning of `..` and `...` as
used in revision ranges for `git log` to `git diff`. The later does not
receive revision ranges as a parameter - as can be seen in the manual:

> git diff [--options] \<commit\> \<commit\> [--] [<path>...]
>   This is to view the changes between two arbitrary <commit>.
>
> git diff [--options] \<commit\>..\<commit\> [--] [<path>...]
>   This is synonymous to the previous form. If <commit> on one side is omitted, it will have the same effect as using HEAD instead.
>
> git diff [--options] \<commit\>...\<commit\> [--] [<path>...]
>   This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both \<commit\>. "git diff A...B" is equivalent to "git diff $(git-merge-base A B) B". You can omit any one of \<commit\>, which has the same effect as using HEAD instead.

This commit reverts commit ec181faaf5ceb6834850f0996698d17c2980138c
and f3a4d37ed8fe3fdf3d311d06e1146a068e1bbef7.