### PR TITLE
Aggregate core.editor command list in Appendix C

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -45,13 +45,11 @@ In <<ch01-getting-started#_editor>> the configuration commands for Emacs and Not
 |Editor | Configuration command
 |Atom |`git config --global core.editor "atom --wait"`
 |BBEdit (Mac, with command line tools) |`git config --global core.editor "bbedit -w"`
-|Emacs |`git config --global core.editor "emacs"`
 |Gedit (Linux) |`git config --global core.editor "gedit --wait --new-window"`
 |Gvim (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Vim/vim72/gvim.exe' --nofork '%*'"`
 |Kate (Linux) |`git config --global core.editor "kate"`
 |nano |`git config --global core.editor "nano -w"`
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
-|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
 |Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
 |Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Sublime Text 3/sublime_text.exe' -w"`

--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -34,6 +34,36 @@ In <<ch08-customizing-git#_keyword_expansion>> we showed how to set up smudge an
 
 Finally, basically the entirety of <<ch08-customizing-git#_git_config>> is dedicated to the command.
 
+[[_core_editor]]
+==== git config core.editor commands
+
+In <<ch01-getting-started#_editor>> the configuration commands for Emacs and Notepad++ are shown as examples. Other editors can be set as follows:
+
+.Exhaustive list of `core.editor` configuration commands
+[cols="1,2",options="header"]
+|==============================
+|Editor | Configuration command
+|Atom |`git config --global core.editor "atom --wait"`
+|BBEdit (Mac, with command line tools) |`git config --global core.editor "bbedit -w"`
+|Emacs |`git config --global core.editor "emacs"`
+|Gedit (Linux) |`git config --global core.editor "gedit --wait --new-window"`
+|Gvim (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Vim/vim72/gvim.exe' --nofork '%*'"`
+|Kate (Linux) |`git config --global core.editor "kate"`
+|nano |`git config --global core.editor "nano -w"`
+|Notepad (Windows 64-bit) |`git config core.editor notepad`
+|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`
+|Notepad++ (Windows 32-bit) |`git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`
+|Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
+|Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
+|Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Sublime Text 3/sublime_text.exe' -w"`
+|Sublime Text (Windows 32-bit) |`git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"`
+|Textmate |`git config --global core.editor "mate -w"`
+|Textpad (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/TextPad 5/TextPad.exe' -m`
+|Vim |`git config --global core.editor "vim"`
+|VS Code |`git config --global core.editor "code --wait"`
+|WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
+|==============================
+
 ==== git help
 
 The `git help` command is used to show you all the documentation shipped with Git about any command.

--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -52,17 +52,20 @@ In <<ch01-getting-started#_editor>> the configuration commands for Emacs and Not
 |nano |`git config --global core.editor "nano -w"`
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
 |Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`
-|Notepad++ (Windows 32-bit) |`git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"`
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
 |Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
 |Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Sublime Text 3/sublime_text.exe' -w"`
-|Sublime Text (Windows 32-bit) |`git config --global core.editor "'c:/program files (x86)/sublime text 3/sublime_text.exe' -w"`
 |Textmate |`git config --global core.editor "mate -w"`
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/TextPad 5/TextPad.exe' -m`
 |Vim |`git config --global core.editor "vim"`
 |VS Code |`git config --global core.editor "code --wait"`
 |WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
 |==============================
+
+[NOTE]
+====
+If you have a 32-bit editor on a Windows 64-bit system, the program will be installed in `C:\Program Files (x86)\` rather than `C:\Program Files\` as in the table above.
+====
 
 ==== git help
 

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -69,7 +69,7 @@ If you are on a 32-bit Windows system, or you have a 64-bit editor on a 64-bit s
 
 [source,console]
 ----
-$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
+$ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"
 ----
 
 [NOTE]

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -72,17 +72,10 @@ If you are on a 32-bit Windows system, or you have a 64-bit editor on a 64-bit s
 $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -nosession"
 ----
 
-If you have a 32-bit editor on a 64-bit system, the program will be installed in `C:\Program Files (x86)`:
-
-[source,console]
-----
-$ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.exe' -multiInst -nosession"
-----
-
 [NOTE]
 ====
 Vim, Emacs and Notepad++ are popular text editors often used by developers on Unix-based systems like Linux and macOS or a Windows system.
-If you are using another editor, please find specific instructions for how to set up your favorite editor with Git in <<C-git-commands#_core_editor>>.
+If you are using another editor, or a 32-bit version, please find specific instructions for how to set up your favorite editor with Git in <<C-git-commands#_core_editor>>.
 ====
 
 [WARNING]

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -48,6 +48,7 @@ If you want to override this with a different name or email address for specific
 
 Many of the GUI tools will help you do this when you first run them.
 
+[[_editor]]
 ==== Your Editor
 
 Now that your identity is set up, you can configure the default text editor that will be used when Git needs you to type in a message.
@@ -81,7 +82,7 @@ $ git config --global core.editor "'C:/Program Files (x86)/Notepad++/notepad++.e
 [NOTE]
 ====
 Vim, Emacs and Notepad++ are popular text editors often used by developers on Unix-based systems like Linux and macOS or a Windows system.
-If you are not familiar with these editors, you may need to search for specific instructions for how to set up your favorite editor with Git.
+If you are using another editor, please find specific instructions for how to set up your favorite editor with Git in <<C-git-commands#_core_editor>>.
 ====
 
 [WARNING]


### PR DESCRIPTION
Close #1269.

I have not tested most these commands, except for Atom & Sublime and am not sure about:

- [ ] list `gvim` at all, given that it's also a default setting: https://git-scm.com/docs/git-var

Maybe worth discussing, besides reviewing the commands:

- [ ] add "(default)" behind the ["Vim" mention in `first-time-setup.asc`](https://github.com/progit/progit2/blame/f52df9b858ee7533f15fd48248858881f6588105/book/01-introduction/sections/first-time-setup.asc#L83); There is no example command, and novices might not find https://git-scm.com/docs/git-var to clarify this by themselves.

### Preview

![image](https://user-images.githubusercontent.com/9948149/59793802-bf806f00-92d7-11e9-8db1-edeac361836d.png)
