### PR TITLE
Specify the branch the HEAD points to on init

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -96,7 +96,7 @@ image::images/reset-workflow.png[]
 
 Let's visualize this process: say you go into a new directory with a single file in it.
 We'll call this *v1* of the file, and we'll indicate it in blue.
-Now we run `git init`, which will create a Git repository with a HEAD reference which points to an unborn branch (`master` doesn't exist yet).
+Now we run `git init`, which will create a Git repository with a HEAD reference which points to the unborn `master` branch.
 
 image::images/reset-ex1.png[]
 


### PR DESCRIPTION
I would like to propose to specify the exact branch the HEAD points
to after the git init command invoking.