### PR TITLE
Running "git rebase -i HEAD~3" won't always rewrite commits

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -69,7 +69,7 @@ It may be easier to remember the `~3` because you're trying to edit the last thr
 $ git rebase -i HEAD~3
 ----
 
-Remember again that this is a rebasing command -- every commit included in the range `HEAD~3..HEAD` will be rewritten, whether you change the message or not.
+Remember again that this is a rebasing command -- every commit in the range `HEAD~3..HEAD` with a changed message _and all of its descendants_ will be rewritten.
 Don't include any commit you've already pushed to a central server -- doing so will confuse other developers by providing an alternate version of the same change.
 
 Running this command gives you a list of commits in your text editor that looks something like this:


### PR DESCRIPTION
The commits will be rewritten only when the todo list is modified.

Fixes #1277