### PR TITLE
git_repository_set_odb call needs repo as input

### DIFF
--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -131,7 +131,7 @@ error = git_odb_add_backend(odb, my_backend, 1); // <3>
 
 git_repository *repo;
 error = git_repository_open(&repo, "some-path");
-error = git_repository_set_odb(odb); // <4>
+error = git_repository_set_odb(repo, odb); // <4>
 ----
 
 _(Note that errors are captured, but not handled. We hope your code is better than ours.)_


### PR DESCRIPTION
the example use of git_repository_set_odb was wrong on the document. It requires repo as input, but was missed.