### PR TITLE
bash prompt example: add a missing escape

### DIFF
--- a/book/A-git-in-other-environments/sections/bash.asc
+++ b/book/A-git-in-other-environments/sections/bash.asc
@@ -30,7 +30,7 @@ To add these to your prompt, just copy the `contrib/completion/git-prompt.sh` fi
 -----
 . ~/git-prompt.sh
 export GIT_PS1_SHOWDIRTYSTATE=1
-export PS1='\w$(__git_ps1 " (%s)")\$ '
+export PS1='\w\$(__git_ps1 " (%s)")\$ '
 -----
 
 The `\w` means print the current working directory, the `\$` prints the `$` part of the prompt, and `__git_ps1 " (%s)"` calls the function provided by `git-prompt.sh` with a formatting argument.


### PR DESCRIPTION
Without this escape, the `__git_ps1` is evaluated directly when `.bashrc` is run, and not when a new prompt is needed, which causes the prompt to never update.