### PR TITLE
Getting Help: fix inconsistency with '-h' option

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -21,7 +21,7 @@ These commands are nice because you can access them anywhere, even offline.
 If the manpages and this book aren't enough and you need in-person help, you can try the `#git` or `#github` channel on the Freenode IRC server, which can be found at https://freenode.net[].
 These channels are regularly filled with hundreds of people who are all very knowledgeable about Git and are often willing to help.(((IRC)))
 
-In addition, if you don't need the full-blown manpage help, but just need a quick refresher on the available options for a Git command, you can ask for the more concise ``help'' output with the `-h` or `--help` options, as in:
+In addition, if you don't need the full-blown manpage help, but just need a quick refresher on the available options for a Git command, you can ask for the more concise ``help'' output with the `-h` option, as in:
 
 [source,console]
 ----


### PR DESCRIPTION
Only the short `-h` option shows the concise help output; the long `--help` option actually opens the manpage, as mentioned at the beginning of the "Getting Help" section. 

This PR fixes the inconsistency in the text.