### PR TITLE
Add tip about abbreviating long git options

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -8,6 +8,13 @@ However, this leaves us with examples of usage of the commands somewhat scattere
 In this appendix, we'll go through all the Git commands we addressed throughout the book, grouped roughly by what they're used for.
 We'll talk about what each command very generally does and then point out where in the book you can find us having used it.
 
+[TIP]
+====
+You can abbreviate long options.
+For example, you can type in `git commit --a`, which acts as if you typed `git commit --amend`.
+This only works when the letters after `--` are unique for one option.
+Do use the full option when writing scripts.
+====
 
 === Setup and Config
 


### PR DESCRIPTION
This pull-request changes:

- Add tip about abbreviating long git options to the beginning of Appendix C.

Fixes #1315