### PR TITLE
Add caution git-tf EOL, change links to Codeplex

### DIFF
--- a/book/09-git-and-other-scms/sections/client-tfs.asc
+++ b/book/09-git-and-other-scms/sections/client-tfs.asc
@@ -20,7 +20,13 @@ Libgit2 is not a complete implementation of Git, so to cover the difference git-
 Its support of TFVC features is very mature, since it uses the Visual Studio assemblies for operations with servers.
 This does mean you'll need access to those assemblies, which means you need to install a recent version of Visual Studio (any edition since version 2010, including Express since version 2012), or the Visual Studio SDK.
 
-Git-tf (whose home is at https://gittf.codeplex.com[]) is a Java project, and as such runs on any computer with a Java runtime environment.
+[CAUTION]
+----
+Git-tf is End-of-Life (EOL), it will not get any updates.
+It is also no longer supported by Microsoft.
+----
+
+Git-tf (whose home is at https://archive.codeplex.com/?p=gittf[]) is a Java project, and as such runs on any computer with a Java runtime environment.
 It interfaces with Git repositories through JGit (a JVM implementation of Git), which means it has virtually no limitations in terms of Git functions.
 However, its support for TFVC is limited as compared to git-tfs – it does not support branches, for instance.
 
@@ -31,7 +37,7 @@ We'll cover the basic usage of both of them in this book.
 ====
 You'll need access to a TFVC-based repository to follow along with these instructions.
 These aren't as plentiful in the wild as Git or Subversion repositories, so you may need to create one of your own.
-Codeplex (https://www.codeplex.com[]) or Visual Studio Online (https://visualstudio.microsoft.com[]) are both good choices for this.
+Codeplex (https://archive.codeplex.com/[]) or Visual Studio Online (https://visualstudio.microsoft.com[]) are both good choices for this.
 ====
 
 


### PR DESCRIPTION
This pull-request changes:

- Change links to codeplex to point to the archival pages.
- Add caution about git-tf being End-of-Life.

I think this section needs more work though, I would advocate to remove the git-tf part wholesale.
Git-tf clone from codeplex.com will also not work anymore I think.

But a big removal like that is up to @ben and team to decide. 😄 

Related: #1304