### PR TITLE
Remove redundant command

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -107,7 +107,6 @@ If you're using a RPM-based distribution (Fedora/RHEL/RHEL-derivatives), you als
 [source,console]
 ----
 $ sudo dnf install getopt
-$ sudo apt-get install getopt
 ----
 
 Additionally, if you're using Fedora/RHEL/RHEL-derivatives, you need to do this


### PR DESCRIPTION
We don't need to run command
```
$ sudo apt-get install getopt
```
because `getopt` already installed on Debian-based systems (as mentioned above).