### PR TITLE
Correct confusing grammar

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -138,7 +138,7 @@ image::images/interesting-rebase-5.png[Final commit history.]
 (((rebasing, perils of)))
 Ahh, but the bliss of rebasing isn't without its drawbacks, which can be summed up in a single line:
 
-*Do not rebase commits that exist outside your repository and people may have based work on them.*
+*Do not rebase commits that exist outside your repository and that people may have based work on.*
 
 If you follow that guideline, you'll be fine.
 If you don't, people will hate you, and you'll be scorned by friends and family.


### PR DESCRIPTION
The phrasing in a warning was confusing.