### PR TITLE
Gemfile: stable version with latest version of gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'asciidoctor', '1.5.6.1'
+gem 'asciidoctor', '~> 2.0', '>= 2.0.10'
 
 gem 'json'
 gem 'awesome_print'
 
-gem 'asciidoctor-epub3', :git => 'https://github.com/asciidoctor/asciidoctor-epub3'
-gem 'asciidoctor-pdf', '1.5.0.alpha.16'
+gem 'asciidoctor-epub3', '~> 1.5.0.alpha.9'
+gem 'asciidoctor-pdf', '~> 1.5.0.beta.8'
 
 gem 'coderay'
 gem 'pygments.rb'


### PR DESCRIPTION
This commit updates Gemfile to use the latest version of gems and makes a problem with `bundle install` disappear:
```console
$ bundle install
Fetching https://github.com/asciidoctor/asciidoctor-epub3
error: cannot open .git/FETCH_HEAD: Permission denied
Retrying git fetch --force --quiet --tags "/home/<user>/.bundler/cache/git/asciidoctor-epub3-3986efa04ab5fd28abe5678d7e330e173e425f18" due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --tags "/home/<user>/.bundler/cache/git/asciidoctor-epub3-3986efa04ab5fd28abe5678d7e330e173e425f18"` in directory /usr/share/gems/bundler/gems/asciidoctor-epub3-c8ca2e297cd1 has failed.
If this error persists you could try removing the cache directory '/home/<user>/.bundler/cache/git/asciidoctor-epub3-3986efa04ab5fd28abe5678d7e330e173e425f18'
```
See #1068 