### PR TITLE
Add caution: use `git filter-repo` instead of `git filter-branch`

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -304,6 +304,13 @@ The command is `filter-branch`, and it can rewrite huge swaths of your history, 
 However, it can be very useful.
 You'll learn a few of the common uses so you can get an idea of some of the things it's capable of.
 
+[CAUTION]
+====
+`git filter-branch` has many pitfalls, and is no longer the recommended way to rewrite history.
+Instead, consider using `git-filter-repo`, which is a Python script that does a better job for most applications where you would normally turn to `filter-branch`.
+Its documentation and source code can be found at https://github.com/newren/git-filter-repo[].
+====
+
 [[_removing_file_every_commit]]
 ===== Removing a File from Every Commit
 


### PR DESCRIPTION
This commit adds:
- a caution block in the relevant part of the book.
- a link to the repository/documentation.

Context:
The git-scm reference documentation for `filter-branch`
warns against using `git filter-branch`,
and recommends using `git filter-repo`.