### PR TITLE
Create initial dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  # Update your Gemfile (& lockfiles) as soon as
+  # new versions are published to the RubyGems registry
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+
+    # Apply default reviewer and label to created
+    # pull requests
+    default_reviewers:
+      - "ben"
+    default_labels:
+      - "dependabot"


### PR DESCRIPTION
This is a initial dependabot config for the ProGit2 project.

There are some important choices to make:

1. How often should dependabot check for non-security updates? Live/daily on weekdays/weekly/monthly? *Security updates are always created as soon as possible.*
2. Should there be a default reviewer?
3. Should the dependabot pull-request have a GitHub label?
4. Dependabot can automatically merge a pull-request if the Travis CI is okay. Is this something you want?

---

What the current config will give you:
- Live updates for non-security updates.
- @ben is the default reviewer and will thus get a email/notification from Dependabot whenever there is a new update.
- The pull-request that dependabot opens will have the label: "dependabot". This label will need to be created.
- Dependabot *will not* automatically merge a pull-request.

The dependabot configuration documentation can be found here:
https://dependabot.com/docs/config-file/

---

This is only a starting point. Please give feedback on what you would like, and I'll incorporate that in the config file.

The owner of the repository will have to sign-up to the Dependabot service here:
https://dependabot.com/