### PR TITLE
asciidoctor version downgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'asciidoctor', '~> 2.0', '>= 2.0.10'
+gem 'asciidoctor', '1.5.6.2'
 
 gem 'json'
 gem 'awesome_print'


### PR DESCRIPTION
using asciidoctor version > 1.5.6.2 makes cross-reference links not work