### PR TITLE
upgrade to asciidoctor 1.5.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'asciidoctor', '1.5.6.2'
+gem 'asciidoctor', '1.5.8'
 
 gem 'json'
 gem 'awesome_print'

--- a/progit.asc
+++ b/progit.asc
@@ -1,5 +1,4 @@
-Pro Git
-=======
+= Pro Git
 Scott Chacon; Ben Straub
 :doctype: book
 :docinfo:


### PR DESCRIPTION
remove compat mode set by setext-style (i.e., two-line) section title
see https://asciidoctor.org/docs/migration/#compat-mode