### PR TITLE
Add note: `git log` doesn't show upstream branches

### DIFF
--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -131,7 +131,7 @@ If you were to run `git log` right now, you might wonder where the "testing" bra
 
 The branch hasn't disappeared; git just doesn't know that you're interested in that branch and it is trying to show you what it thinks you're interested in. In other words, by default, `git log` will only show commits below the branch you've checked out.
 
-To show all of the branches, add `--all` to your `git log` command. When multiple branches get involved, the command, `git log --all --graph`, might prove helpful, as it will show a more graphical representation of the repository.
+To show all of the branches, add `--all` to your `git log` command. 
 ====
 
 .HEAD moves when you checkout

--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -129,7 +129,8 @@ $ git checkout master
 ====
 If you were to run `git log` right now, you might wonder where the "testing" branch you just created went, as it would not appear in the output. 
 
-The branch hasn't disappeared; git just doesn't know that you're interested in that branch and it is trying to show you what it thinks you're interested in. In other words, by default, `git log` will only show commits below the branch you've checked out.
+The branch hasn't disappeared; git just doesn't know that you're interested in that branch and it is trying to show you what it thinks you're interested in. 
+In other words, by default, `git log` will only show commits below the branch you've checked out.
 
 To show all of the branches, add `--all` to your `git log` command. 
 ====

--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -124,6 +124,16 @@ Let's switch back to the `master` branch:
 $ git checkout master
 ----
 
+[NOTE]
+.`git log` doesn't show _all_ the branches _all_ the time
+====
+If you were to run `git log` right now, you might wonder where the "testing" branch you just created went, as it would not appear in the output. 
+
+The branch hasn't disappeared; git just doesn't know that you're interested in that branch and it is trying to show you what it thinks you're interested in. In other words, by default, `git log` will only show commits below the branch you've checked out.
+
+To show all of the branches, add `--all` to your `git log` command. When multiple branches get involved, the command, `git log --all --graph`, might prove helpful, as it will show a more graphical representation of the repository.
+====
+
 .HEAD moves when you checkout
 image::images/checkout-master.png[HEAD moves when you checkout.]
 


### PR DESCRIPTION
I'm reading the book for the first time. I found something confusing so I've added what I hope is a helpful note.

I found it confusing when I tried to use `git log` to replicate what is shown in the graphic (named "HEAD moves when you checkout"); I thought I would see both the "testing" and "master" branches, like in the graphic, but was only able to see "master".

If I've said something incorrect in my note, feel free to change it or let me know how I can improve it—like I mentioned, I'm just reading the book for the first time—I'm happy to incorporate the advice of those wiser than I.