### PR TITLE
Replace mention of "ticket" with "issue"

### DIFF
--- a/book/03-git-branching/sections/basic-branching-and-merging.asc
+++ b/book/03-git-branching/sections/basic-branching-and-merging.asc
@@ -174,7 +174,7 @@ This is referred to as a merge commit, and is special in that it has more than o
 image::images/basic-merging-2.png[A merge commit.]
 
 Now that your work is merged in, you have no further need for the `iss53` branch.
-You can close the ticket in your ticket-tracking system, and delete the branch:
+You can close the issue in your issue-tracking system, and delete the branch:
 
 [source,console]
 ----


### PR DESCRIPTION
I suspect it's clearer to talk about issues instead of tickets. Everyone knows what an issue is. Not everyone has worked with a ticket system; maybe they'll wonder if tickets are part of git. Sticking to the word "issues" seems to allow us to lose no clarity while reducing the chance for confusion.

I'm willing to consider other opinions, however.