### PR TITLE
A missing word and a clarification

### DIFF
--- a/book/04-git-server/sections/protocols.asc
+++ b/book/04-git-server/sections/protocols.asc
@@ -129,7 +129,7 @@ It is also a very fast and efficient protocol, similar to the SSH one.
 
 You can also serve your repositories read-only over HTTPS, which means you can encrypt the content transfer; or you can go so far as to make the clients use specific signed SSL certificates.
 
-Another nice thing is that HTTPS are such commonly used protocols that corporate firewalls are often set up to allow traffic through these ports.
+Another nice thing is that HTTP and HTTPS are such commonly used protocols that corporate firewalls are often set up to allow traffic through their ports.
 
 ===== The Cons
 


### PR DESCRIPTION
As it was, the parts of the sentence didn't quite agree with each other. Adding "HTTP" alongside "HTTPS" restored the agreement that I suspect the sentence originally had.

Also, I changed "these ports" to "their ports" because the specific ports that the protocols use aren't mentioned. "These ports" seems to refer to ports that were previously mentioned in the text; "their ports" intends to refer to the ports belonging to the protocols.