### PR TITLE
Stop adding negative leveloffset for EPUB

### DIFF
--- a/progit.asc
+++ b/progit.asc
@@ -8,8 +8,6 @@ Scott Chacon; Ben Straub
 :front-cover-image: image:book/cover.png[width=1050,height=1600]
 :icons: font
 
-ifdef::ebook-format[:leveloffset: -1]
-
 include::book/license.asc[]
 
 include::book/preface_schacon.asc[]


### PR DESCRIPTION
asciidoctor-epub3 1.5.0-alpha-14 and newer now parses whole book as a single document.

Negative leveloffset
1. Breaks appendix hierarchy because Asciidoctor doesn't allow appendix subsections to be higher that level 3. When leveloffset is applied to them, they become level 2 and are no longer children of appendix and instead become standalone chapters
2. Transforms progit into a multi-part book instead of multi-chapter book, what I think is wrong

After removal of negative offset, EPUB is structurally equivalent to other formats.