### PR TITLE
(#1395) Partial globbing is available in refspec since git 2.6.0

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -75,14 +75,14 @@ If you want to always fetch the `master` and `experiment` branches from the `ori
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-You can't use partial globs in the pattern, so this would be invalid:
+Since Git 2.6.0 you can use partial globs in the pattern to match multiple branches, so this works:
 
 [source,ini]
 ----
 fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
-However, you can use namespaces (or directories) to accomplish something like that.
+Even better, you can use namespaces (or directories) to accomplish the same with more structure.
 If you have a QA team that pushes a series of branches, and you want to get the `master` branch and any of the QA team's branches but nothing else, you can use a config section like this:
 
 [source,ini]


### PR DESCRIPTION
## Motivation
The docs were saying that partial glob patterns are unavailable in
refspec, and namespacing is the only way to get flexible refspecs
matching multiple branches. This is no longer true since Git 2.6.0 which
added support for partial globbing patterns.

## Modifications
The outdated paragraph was changed so that it now explicitly states that
the approach works.

Closes #1395.