### PR TITLE
Update go-git URL in Appendinx B: embedding

### DIFF
--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -5,16 +5,16 @@ In case you want to integrate Git into a service written in Golang, there also i
 This implementation does not have any native dependencies and thus is not prone to manual memory management errors.
 It is also transparent for the standard Golang performance analysis tooling like CPU, Memory profilers, race detector, etc.
 
-go-git is focused on extensibility, compatibility and supports most of the plumbing APIs, which is documented at https://github.com/src-d/go-git/blob/master/COMPATIBILITY.md[].
+go-git is focused on extensibility, compatibility and supports most of the plumbing APIs, which is documented at https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md[].
 
 Here is a basic example of using Go APIs:
 
 [source, go]
 -----
-import 	"gopkg.in/src-d/go-git.v4"
+import "github.com/go-git/go-git/v5"
 
 r, err := git.PlainClone("/tmp/foo", false, &git.CloneOptions{
-    URL:      "https://github.com/src-d/go-git",
+    URL:      "https://github.com/go-git/go-git",
     Progress: os.Stdout,
 })
 -----
@@ -48,17 +48,17 @@ The default implementation is in-memory storage, which is very fast.
 [source, go]
 -----
 r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
-    URL: "https://github.com/src-d/go-git",
+    URL: "https://github.com/go-git/go-git",
 })
 -----
 
 Pluggable storage provides many interesting options.
-For instance, https://github.com/src-d/go-git/tree/master/_examples/storage[] allows you to store references, objects, and configuration in an Aerospike database.
+For instance, https://github.com/go-git/go-git/tree/master/_examples/storage[] allows you to store references, objects, and configuration in an Aerospike database.
 
 Another feature is a flexible filesystem abstraction.
-Using https://godoc.org/github.com/src-d/go-billy#Filesystem[] it is easy to store all the files in different way i.e by packing all of them to a single archive on disk or by keeping them all in-memory.
+Using https://pkg.go.dev/github.com/go-git/go-billy/v5?tab=doc#Filesystem[] it is easy to store all the files in different way i.e by packing all of them to a single archive on disk or by keeping them all in-memory.
 
-Another advanced use-case includes a fine-tunable HTTP client, such as the one found at https://github.com/src-d/go-git/blob/master/_examples/custom_http/main.go[].
+Another advanced use-case includes a fine-tunable HTTP client, such as the one found at https://github.com/go-git/go-git/blob/master/_examples/custom_http/main.go[].
 
 [source, go]
 -----
@@ -83,4 +83,4 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url})
 ==== Further Reading
 
 A full treatment of go-git's capabilities is outside the scope of this book.
-If you want more information on go-git, there's API documentation at https://godoc.org/gopkg.in/src-d/go-git.v4[], and a set of usage examples at https://github.com/src-d/go-git/tree/master/_examples[].
+If you want more information on go-git, there's API documentation at https://pkg.go.dev/github.com/go-git/go-git/v5[], and a set of usage examples at https://github.com/go-git/go-git/tree/master/_examples[].


### PR DESCRIPTION
You can read about the project status at: https://github.com/go-git/go-git/wiki/go-git-has-a-new-home!-v5-and-some-explanations