### PR TITLE
Harmonize slashes as backward all Windows paths

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -67,13 +67,13 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/TextPad 5/TextPad.exe' -m` (Also see note below)
 |Vim |`git config --global core.editor "vim"`
 |Visual Studio Code and VSCodium |`git config --global core.editor "code --wait"`
-|WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
+|WordPad |`git config --global core.editor '"C:/Program Files/Windows NT/Accessories/wordpad.exe"'"`
 |Xi | `git config --global core.editor "xi --wait"`
 |==============================
 
 [NOTE]
 ====
-If you have a 32-bit editor on a Windows 64-bit system, the program will be installed in `C:\Program Files (x86)\` rather than `C:\Program Files\` as in the table above.
+If you have a 32-bit editor on a Windows 64-bit system, the program will be installed in `C:/Program Files (x86)/` rather than `C:/Program Files/` as in the table above.
 ====
 
 ==== git help

--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -54,26 +54,26 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |BBEdit (Mac, with command line tools) |`git config --global core.editor "bbedit -w"`
 |Emacs |`git config --global core.editor emacs`
 |Gedit (Linux) |`git config --global core.editor "gedit --wait --new-window"`
-|Gvim (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Vim/vim72/gvim.exe' --nofork '%*'"` (Also see note below)
+|Gvim (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Vim\vim72\gvim.exe' --nofork '%*'"` (Also see note below)
 |Kate (Linux) |`git config --global core.editor "kate"`
 |nano |`git config --global core.editor "nano -w"`
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
-|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)
+|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Notepad++\notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
 |Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
-|Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/Sublime Text 3/sublime_text.exe' -w"` (Also see note below)
+|Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Sublime Text 3\sublime_text.exe' -w"` (Also see note below)
 |TextEdit (macOS)|`git config --global --add core.editor "open -W -n"`
 |Textmate |`git config --global core.editor "mate -w"`
-|Textpad (Windows 64-bit) |`git config --global core.editor "'C:/Program Files/TextPad 5/TextPad.exe' -m` (Also see note below)
+|Textpad (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\TextPad 5\TextPad.exe' -m` (Also see note below)
 |Vim |`git config --global core.editor "vim"`
 |Visual Studio Code and VSCodium |`git config --global core.editor "code --wait"`
-|WordPad |`git config --global core.editor '"C:/Program Files/Windows NT/Accessories/wordpad.exe"'"`
+|WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
 |Xi | `git config --global core.editor "xi --wait"`
 |==============================
 
 [NOTE]
 ====
-If you have a 32-bit editor on a Windows 64-bit system, the program will be installed in `C:/Program Files (x86)/` rather than `C:/Program Files/` as in the table above.
+If you have a 32-bit editor on a Windows 64-bit system, the program will be installed in `C:\Program Files (x86)\` rather than `C:\Program Files\` as in the table above.
 ====
 
 ==== git help


### PR DESCRIPTION
I'm not entirely sure about this. Maybe `\` everywhere would be less confusing for Windows users?

However, both the Git Bash and cmd.exe seem to accept both versions, at least on my Win10.