### PR TITLE
replaced 'Working Directory' with 'Working Tree', as per general terminology

### DIFF
--- a/images/areas.svg
+++ b/images/areas.svg
@@ -45,7 +45,7 @@
      <g id="ref-(2-line)" transform="translate(4,4)" style="fill-rule:evenodd">
       <rect id="rect1144" width="110.58" height="38" style="fill-rule:evenodd;fill:#f44d27"/>
      </g>
-     <text id="text956" transform="translate(-47.951,73.488)" x="106.99279" y="-53.654934" style="fill:#f0f0e4;font-family:'Source Code Pro';font-feature-settings:normal;font-size:12px;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-weight:bold;letter-spacing:0px;line-height:13.0666666px;text-align:center;text-anchor:middle;word-spacing:0px" xml:space="preserve"><tspan id="tspan954" x="106.99279" y="-53.654934" style="fill:#f0f0e4;line-height:13.0666666px">Working</tspan><tspan id="tspan958" x="106.99279" y="-40.588268" style="fill:#f0f0e4;line-height:13.0666666px">Directory</tspan></text>
+     <text id="text956" transform="translate(-47.951,73.488)" x="106.99279" y="-53.654934" style="fill:#f0f0e4;font-family:'Source Code Pro';font-feature-settings:normal;font-size:12px;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-weight:bold;letter-spacing:0px;line-height:13.0666666px;text-align:center;text-anchor:middle;word-spacing:0px" xml:space="preserve"><tspan id="tspan954" x="106.99279" y="-53.654934" style="fill:#f0f0e4;line-height:13.0666666px">Working</tspan><tspan id="tspan958" x="106.99279" y="-40.588268" style="fill:#f0f0e4;line-height:13.0666666px">Tree</tspan></text>
     </g>
    </g>
   </g>


### PR DESCRIPTION
The image at https://git-scm.com/book/en/v2/images/areas.png labels the first box in the upper left "Working Directory". However, all over the text, including the image caption at https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F, the term "Working tree" is used.

I don't know how to regenerate the png, any hints?