### PR TITLE
Move VSCodium and use the proper command

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -67,7 +67,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\TextPad 5\TextPad.exe' -m` (Also see note below)
 |Vim |`git config --global core.editor "vim"`
 |Visual Studio Code |`git config --global core.editor "code --wait"`
-|VSCodium (Free/Libre Open source binaries of VSCode) | `git config --global core.editor "codium --wait"`
+|VSCodium (Free/Libre Open Source Software Binaries of VSCode) | `git config --global core.editor "codium --wait"`
 |WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
 |Xi | `git config --global core.editor "xi --wait"`
 |==============================

--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -66,7 +66,8 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Textmate |`git config --global core.editor "mate -w"`
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\TextPad 5\TextPad.exe' -m` (Also see note below)
 |Vim |`git config --global core.editor "vim"`
-|Visual Studio Code and VSCodium |`git config --global core.editor "code --wait"`
+|Visual Studio Code |`git config --global core.editor "code --wait"`
+|VSCodium (Free/Libre Open source binaries of VSCode) | `git config --global core.editor "codium --wait"`
 |WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`
 |Xi | `git config --global core.editor "xi --wait"`
 |==============================


### PR DESCRIPTION
VSCodium uses `codium` as as the name of the binary. Using `git config --global core.editor "code --wait"` will not work properly with VSCodium.

This pull-request moves VSCodium to it's own line, and uses the proper command to setup VSCodium as the core editor.

Reference for VSCodium terminal usage:
https://github.com/VSCodium/vscodium/blob/master/DOCS.md#how-do-i-open-vscodium-from-the-terminal