### PR TITLE
Error when describing the Smart Protocol?

### DIFF
--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -153,9 +153,9 @@ $ ssh -x git@server "git-receive-pack 'simplegit-progit.git'"
 The `git-receive-pack` command immediately responds with one line for each reference it currently has – in this case, just the `master` branch and its SHA-1.
 The first line also has a list of the server's capabilities (here, `report-status`, `delete-refs`, and some others, including the client identifier).
 
-Each line starts with a 4-character hex value specifying how long the whole the line is (including the 4-character length itself and the trailing linefeed).
-Your first line starts with 00a5, which is hexadecimal for 165, meaning the line is 165 bytes long.
-The next line is 0000, meaning the server is done with its references listing.
+The data is transmitted in chunks. Each chunk starts with a 4-character hex value specifying how long the chunk is (including the 4 bytes of the length itself). Chunks usually contain a single line of data and a trailing linefeed.
+Your first chunk starts with 00a5, which is hexadecimal for 165, meaning the chunk is 165 bytes long.
+The next chunk is 0000, meaning the server is done with its references listing.
 
 Now that it knows the server's state, your `send-pack` process determines what commits it has that the server doesn't.
 For each reference that this push will update, the `send-pack` process tells the `receive-pack` process that information.
@@ -208,6 +208,8 @@ The client then makes another request, this time a `POST`, with the data that `s
 
 The `POST` request includes the `send-pack` output and the packfile as its payload.
 The server then indicates success or failure with its HTTP response.
+
+
 
 ===== Downloading Data
 

--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -153,8 +153,8 @@ $ ssh -x git@server "git-receive-pack 'simplegit-progit.git'"
 The `git-receive-pack` command immediately responds with one line for each reference it currently has – in this case, just the `master` branch and its SHA-1.
 The first line also has a list of the server's capabilities (here, `report-status`, `delete-refs`, and some others, including the client identifier).
 
-Each line starts with a 4-character hex value specifying how long the rest of the line is.
-Your first line starts with 00a5, which is hexadecimal for 165, meaning that 165 bytes remain on that line.
+Each line starts with a 4-character hex value specifying how long the whole the line is (including the 4-character length itself and the trailing linefeed).
+Your first line starts with 00a5, which is hexadecimal for 165, meaning the line is 165 bytes long.
 The next line is 0000, meaning the server is done with its references listing.
 
 Now that it knows the server's state, your `send-pack` process determines what commits it has that the server doesn't.

--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -153,7 +153,9 @@ $ ssh -x git@server "git-receive-pack 'simplegit-progit.git'"
 The `git-receive-pack` command immediately responds with one line for each reference it currently has – in this case, just the `master` branch and its SHA-1.
 The first line also has a list of the server's capabilities (here, `report-status`, `delete-refs`, and some others, including the client identifier).
 
-The data is transmitted in chunks. Each chunk starts with a 4-character hex value specifying how long the chunk is (including the 4 bytes of the length itself). Chunks usually contain a single line of data and a trailing linefeed.
+The data is transmitted in chunks.
+Each chunk starts with a 4-character hex value specifying how long the chunk is (including the 4 bytes of the length itself).
+Chunks usually contain a single line of data and a trailing linefeed.
 Your first chunk starts with 00a5, which is hexadecimal for 165, meaning the chunk is 165 bytes long.
 The next chunk is 0000, meaning the server is done with its references listing.
 

--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -209,7 +209,7 @@ The client then makes another request, this time a `POST`, with the data that `s
 The `POST` request includes the `send-pack` output and the packfile as its payload.
 The server then indicates success or failure with its HTTP response.
 
-
+Keep in mind the HTTP protocol may further wrap this data inside a chunked transfer encoding.
 
 ===== Downloading Data
 


### PR DESCRIPTION
It currently says (emphasis mine):

> Each line starts with a 4-character hex value specifying **how long the rest of the line is**.
> Your first line starts with 00a5, which is hexadecimal for 165, meaning that 165 bytes remain on that line.

This is inconsistent with the examples; the length seems to include its own 4 characters, and the linefeed:

~~~ js
line = '003fe2409a098dc3e53539a9028a94b6224db9d6a6b6 refs/heads/master\n'
line.length === 0x3f
~~~