### PR TITLE
submodules.asc: clarify DbConnector/try-merge example

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -605,7 +605,7 @@ This is what you'll have to merge in and resolve.
 You can either just try the merge with the SHA-1 directly, or you can create a branch for it and then try to merge that in.
 We would suggest the latter, even if only to make a nicer merge commit message.
 
-So, we will go into our submodule directory, create a branch based on that second SHA-1 from `git diff` and manually merge.
+So, we will go into our submodule directory, create a branch named ``try-merge'' based on that second SHA-1 from `git diff`, and manually merge.
 
 [source,console]
 ----
@@ -615,7 +615,8 @@ $ git rev-parse HEAD
 eb41d764bccf88be77aced643c13a7fa86714135
 
 $ git branch try-merge c771610
-(DbConnector) $ git merge try-merge
+
+$ git merge try-merge
 Auto-merging src/main.c
 CONFLICT (content): Merge conflict in src/main.c
 Recorded preimage for 'src/main.c'


### PR DESCRIPTION
Fix AsciiDoc `source,console` block to render separately the consecutive commands `git branch try-merge c771610` and `git merge try-merge`. This is accomplished by separating the commands with an empty line, and by omitting the unneeded "(DbConnector) " prefix in front of the `git merge...` command prompt. Puts the example into the form consistent with the other command blocks, and also enhances readability.

State explicitly in the prose that "try-merge" will be the name of the branch.
