### PR TITLE
Fix the commit hashes in ch10.2

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -254,7 +254,7 @@ Start with the first tree you wrote:
 [source,console]
 ----
 $ echo 'First commit' | git commit-tree d8329f
-fdf4fc3344e67ab068f836878b6c4951e3b15f3d
+70d4408b5020e81d19906d6abdd87a73233ebf34
 ----
 
 You will get a different hash value because of different creation time and author data.
@@ -263,7 +263,7 @@ Now you can look at your new commit object with `git cat-file`:
 
 [source,console]
 ----
-$ git cat-file -p fdf4fc3
+$ git cat-file -p 70d4408b
 tree d8329fc1cc938780ffdd9f94e0d364e0ea74f579
 author Scott Chacon <schacon@gmail.com> 1243040974 -0700
 committer Scott Chacon <schacon@gmail.com> 1243040974 -0700
@@ -277,10 +277,10 @@ Next, you'll write the other two commit objects, each referencing the commit tha
 
 [source,console]
 ----
-$ echo 'Second commit' | git commit-tree 0155eb -p fdf4fc3
-cac0cab538b970a37ea1e769cbbde608743bc96d
-$ echo 'Third commit'  | git commit-tree 3c4e9c -p cac0cab
-1a410efbd13591db07496601ebc7a059dd55cfe9
+$ echo 'Second commit' | git commit-tree 0155eb -p 70d4408b
+1513b13a72f5277252cfce4ed0eda0620aca2f6a
+$ echo 'Third commit'  | git commit-tree 3c4e9c -p 1513b13a
+95cce637b4e889eee8042515db402128bd62c0d2
 ----
 
 Each of the three commit objects points to one of the three snapshot trees you created.
@@ -289,7 +289,7 @@ Oddly enough, you have a real Git history now that you can view with the `git lo
 [source,console]
 ----
 $ git log --stat 1a410e
-commit 1a410efbd13591db07496601ebc7a059dd55cfe9
+commit 95cce637b4e889eee8042515db402128bd62c0d2
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Fri May 22 18:15:24 2009 -0700
 
@@ -298,7 +298,7 @@ Date:   Fri May 22 18:15:24 2009 -0700
  bak/test.txt | 1 +
  1 file changed, 1 insertion(+)
 
-commit cac0cab538b970a37ea1e769cbbde608743bc96d
+commit 1513b13a72f5277252cfce4ed0eda0620aca2f6a
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Fri May 22 18:14:29 2009 -0700
 
@@ -308,7 +308,7 @@ Date:   Fri May 22 18:14:29 2009 -0700
  test.txt | 2 +-
  2 files changed, 2 insertions(+), 1 deletion(-)
 
-commit fdf4fc3344e67ab068f836878b6c4951e3b15f3d
+commit 70d4408b5020e81d19906d6abdd87a73233ebf34
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Fri May 22 18:09:34 2009 -0700
 
@@ -328,11 +328,12 @@ Here are all the objects in the example directory now, commented with what they 
 ----
 $ find .git/objects -type f
 .git/objects/01/55eb4229851634a0f03eb265b69f5a2d56f341 # tree 2
-.git/objects/1a/410efbd13591db07496601ebc7a059dd55cfe9 # commit 3
+.git/objects/15/13b13a72f5277252cfce4ed0eda0620aca2f6a # commit 2
 .git/objects/1f/7a7a472abf3dd9643fd615f6da379c4acb3e3a # test.txt v2
 .git/objects/3c/4e9cd789d88d8d89c1073707c3585e41b0e614 # tree 3
+.git/objects/70/d4408b5020e81d19906d6abdd87a73233ebf34 # commit 1
 .git/objects/83/baae61804e65cc73a7201a7252750c76066a30 # test.txt v1
-.git/objects/ca/c0cab538b970a37ea1e769cbbde608743bc96d # commit 2
+.git/objects/95/cce637b4e889eee8042515db402128bd62c0d2 # commit 3
 .git/objects/d6/70460b4b4aece5915caf5c68d12f560a9fe3e4 # 'test content'
 .git/objects/d8/329fc1cc938780ffdd9f94e0d364e0ea74f579 # tree 1
 .git/objects/fa/49b077972391ad58037050f2a75f74e3671e92 # new.txt

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -288,7 +288,7 @@ Oddly enough, you have a real Git history now that you can view with the `git lo
 
 [source,console]
 ----
-$ git log --stat 1a410e
+$ git log --stat 95cce6
 commit 95cce637b4e889eee8042515db402128bd62c0d2
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Fri May 22 18:15:24 2009 -0700
@@ -337,7 +337,6 @@ $ find .git/objects -type f
 .git/objects/d6/70460b4b4aece5915caf5c68d12f560a9fe3e4 # 'test content'
 .git/objects/d8/329fc1cc938780ffdd9f94e0d364e0ea74f579 # tree 1
 .git/objects/fa/49b077972391ad58037050f2a75f74e3671e92 # new.txt
-.git/objects/fd/f4fc3344e67ab068f836878b6c4951e3b15f3d # commit 1
 ----
 
 If you follow all the internal pointers, you get an object graph something like this:

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -1,7 +1,7 @@
 [[_git_refs]]
 === Git References
 
-If you were interested in seeing the history of your repository reachable from commit, say, `1a410e`, you could run something like `git log 1a410e` to display that history, but you would still have to remember that `1a410e` is the commit you want to use as the starting point for that history.
+If you were interested in seeing the history of your repository reachable from commit, say, `95cce6`, you could run something like `git log 95cce6` to display that history, but you would still have to remember that `95cce6` is the commit you want to use as the starting point for that history.
 Instead, it would be easier if you had a file in which you could store that SHA-1 value under a simple name so you could use that simple name rather than the raw SHA-1 value.
 
 In Git, these simple names are called ``references'' or ``refs''; you can find the files that contain those SHA-1 values in the `.git/refs` directory.
@@ -20,7 +20,7 @@ To create a new reference that will help you remember where your latest commit i
 
 [source,console]
 ----
-$ echo 1a410efbd13591db07496601ebc7a059dd55cfe9 > .git/refs/heads/master
+$ echo 95cce637b4e889eee8042515db402128bd62c0d2 > .git/refs/heads/master
 ----
 
 Now, you can use the head reference you just created instead of the SHA-1 value in your Git commands:
@@ -28,16 +28,16 @@ Now, you can use the head reference you just created instead of the SHA-1 value 
 [source,console]
 ----
 $ git log --pretty=oneline master
-1a410efbd13591db07496601ebc7a059dd55cfe9 Third commit
-cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
-fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
+95cce637b4e889eee8042515db402128bd62c0d2 Third commit
+1513b13a72f5277252cfce4ed0eda0620aca2f6a Second commit
+70d4408b5020e81d19906d6abdd87a73233ebf34 First commit
 ----
 
 You aren't encouraged to directly edit the reference files; instead, Git provides the safer command `git update-ref` to do this if you want to update a reference:
 
 [source,console]
 ----
-$ git update-ref refs/heads/master 1a410efbd13591db07496601ebc7a059dd55cfe9
+$ git update-ref refs/heads/master 95cce637b4e889eee8042515db402128bd62c0d2
 ----
 
 That's basically what a branch in Git is: a simple pointer or reference to the head of a line of work.
@@ -45,7 +45,7 @@ To create a branch back at the second commit, you can do this:
 
 [source,console]
 ----
-$ git update-ref refs/heads/test cac0ca
+$ git update-ref refs/heads/test 1513b1
 ----
 
 Your branch will contain only work from that commit down:
@@ -53,8 +53,8 @@ Your branch will contain only work from that commit down:
 [source,console]
 ----
 $ git log --pretty=oneline test
-cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
-fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
+1513b13a72f5277252cfce4ed0eda0620aca2f6a Second commit
+70d4408b5020e81d19906d6abdd87a73233ebf34 First commit
 ----
 
 Now, your Git database conceptually looks something like this:
@@ -142,7 +142,7 @@ You can see this by creating an annotated tag (using the `-a` option):
 
 [source,console]
 ----
-$ git tag -a v1.1 1a410efbd13591db07496601ebc7a059dd55cfe9 -m 'Test tag'
+$ git tag -a v1.1 95cce637b4e889eee8042515db402128bd62c0d2 -m 'Test tag'
 ----
 
 Here's the object SHA-1 value it created:
@@ -150,15 +150,15 @@ Here's the object SHA-1 value it created:
 [source,console]
 ----
 $ cat .git/refs/tags/v1.1
-9585191f37f7b0fb9444f35a9bf50de191beadc2
+9585191f37f7b0fb9444f35a9bf50de191beadc2 -- TODO this hash
 ----
 
 Now, run `git cat-file -p` on that SHA-1 value:
 
 [source,console]
 ----
-$ git cat-file -p 9585191f37f7b0fb9444f35a9bf50de191beadc2
-object 1a410efbd13591db07496601ebc7a059dd55cfe9
+$ git cat-file -p 9585191f37f7b0fb9444f35a9bf50de191beadc2 -- TODO this hash
+object 95cce637b4e889eee8042515db402128bd62c0d2
 type commit
 tag v1.1
 tagger Scott Chacon <schacon@gmail.com> Sat May 23 16:48:58 2009 -0700
@@ -201,7 +201,7 @@ Then, you can see what the `master` branch on the `origin` remote was the last t
 [source,console]
 ----
 $ cat .git/refs/remotes/origin/master
-ca82a6dff817ec66f44342007202690a93763949
+ca82a6dff817ec66f44342007202690a93763949 -- TODO can this have changed?
 ----
 
 Remote references differ from branches (`refs/heads` references) mainly in that they're considered read-only.


### PR DESCRIPTION
This fixes the inconsistency introduced in
4f55250d90710652c0948853bb3ffcbd751adeee (#1351), where commit messages were
changed without correspondingly updating the commit hashes.

This is incomplete because I don't yet know how to change the pictures.

The appropriate configuration to use to generate these hashes is:

```
export GIT_AUTHOR_DATE="2009-05-22T18:09:34+00:00-0700" \
export GIT_AUTHOR_EMAIL="schacon@gmail.com" \
export GIT_AUTHOR_NAME="Scott Chacon" \
export GIT_COMMITTER_DATE="2009-05-22T18:09:34+00:00-0700" \
export GIT_COMMITTER_EMAIL="schacon@gmail.com" \
export GIT_COMMITTER_NAME="Scott Chacon"
```