### PR TITLE
fix outdated information about pushing tags

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -220,7 +220,8 @@ Now, when someone else clones or pulls from your repository, they will get all y
 [NOTE]
 .`git push` pushes both types of tags
 ====
-Pushing tags using `git push <remote> --tags` does not distinguish between lightweight and annotated tags; However, if you use `git push <remote> --follow-tags` only annotated tags will be pushed to the remote.
+`git push <remote> --tags` will push both lightweight and annotated tags.
+There is currently no option to push only lightweight tags, but if you use `git push <remote> --follow-tags` only annotated tags will be pushed to the remote.
 ====
 
 ==== Deleting Tags

--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -220,7 +220,7 @@ Now, when someone else clones or pulls from your repository, they will get all y
 [NOTE]
 .`git push` pushes both types of tags
 ====
-Pushing tags using `git push <remote> --tags` does not distinguish between lightweight and annotated tags; there is no simple option that allows you to select just one type for pushing.
+Pushing tags using `git push <remote> --tags` does not distinguish between lightweight and annotated tags; However, if you use `git push <remote> --follow-tags` only annotated tags will be pushed to the remote.
 ====
 
 ==== Deleting Tags


### PR DESCRIPTION
Fix information about pushing only annotated tags

Github issue #1426