### PR TITLE
fix 'Splitting a Commit' rebase bug

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -292,10 +292,10 @@ $ git log -4 --pretty=format:"%h %s"
 1c002dd Add cat-file
 9b29157 Add blame
 35cfb2b Update README formatting
-f3cc40e Change my name a bit
+f7f3f6d Change my name a bit
 ----
 
-Once again, this changes the SHA-1s of all the commits in your list, so make sure no commit shows up in that list that you've already pushed to a shared repository.
+This changes the SHA-1s of the three most recent commits in your list, so make sure no changed commit shows up in that list that you've already pushed to a shared repository.  Notice that the last commit (`f7f3f6d`) in the list is unchanged.  Despite this commit being shown in the script, because it was marked as ``pick'' and was applied prior to any rebase changes, Git leaves the commit unmodified.
 
 ==== The Nuclear Option: filter-branch
 

--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -295,7 +295,9 @@ $ git log -4 --pretty=format:"%h %s"
 f7f3f6d Change my name a bit
 ----
 
-This changes the SHA-1s of the three most recent commits in your list, so make sure no changed commit shows up in that list that you've already pushed to a shared repository.  Notice that the last commit (`f7f3f6d`) in the list is unchanged.  Despite this commit being shown in the script, because it was marked as ``pick'' and was applied prior to any rebase changes, Git leaves the commit unmodified.
+This changes the SHA-1s of the three most recent commits in your list, so make sure no changed commit shows up in that list that you've already pushed to a shared repository.
+Notice that the last commit (`f7f3f6d`) in the list is unchanged.
+Despite this commit being shown in the script, because it was marked as ``pick'' and was applied prior to any rebase changes, Git leaves the commit unmodified.
 
 ==== The Nuclear Option: filter-branch
 


### PR DESCRIPTION
The first commit in the rebase script `f7f3f6d` should be unmodified after the script is complete

fixes #1431