### PR TITLE
fix content length calculation in git objects blob header

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -370,7 +370,7 @@ To that first part of the header, Git adds a space followed by the size in bytes
 
 [source,console]
 ----
->> header = "blob #{content.length}\0"
+>> header = "blob #{content.bytesize}\0"
 => "blob 16\u0000"
 ----
 


### PR DESCRIPTION
Hi, first time contributing so please bear with me if I missed something.

When testing out some code based on the contents of the internals section, I believe I ran into a small mistake. The header should contain the size in bytes of the content, but `content.length` in the example returns the number of characters. Using `bytesize` returns the right value: https://ruby-doc.org/core-2.4.0/String.html#method-i-bytesize

The example works with its content (`what is up, doc?`) but the issue manifests with other characters 
```ruby
irb(main):002:0> content = "i have €5 in my pocket"
=> "i have €5 in my pocket"
irb(main):003:0> content.length
=> 22
irb(main):004:0> content.bytesize
=> 24
irb(main):05:0> sha_w_length = Digest::SHA1.hexdigest("blob #{content.length}\0" + content)
=> "9859c2c849cc5591aa2223a6fb697aeaa9a5f7fe"
irb(main):06:0> sha_w_bytesize = Digest::SHA1.hexdigest("blob #{content.bytesize}\0" + content)
=> "3d446f4f877e1bea82e603328a845ad7b036338e"
```

As expected they result in different sha's. The correct one is the one using `bytesize`
```bash
$ echo -n 'i have €5 in my pocket' | git hash-object --stdin
3d446f4f877e1bea82e603328a845ad7b036338e
```

This PR just tweaks the example to use `bytesize` instead of length