### PR TITLE
Create note with link to git-rebase.io

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -299,6 +299,12 @@ This changes the SHA-1s of the three most recent commits in your list, so make s
 Notice that the last commit (`f7f3f6d`) in the list is unchanged.
 Despite this commit being shown in the script, because it was marked as ``pick'' and was applied prior to any rebase changes, Git leaves the commit unmodified.
 
+[NOTE]
+====
+Drew DeVault made a practical hands-on guide with exercises to learn how to use `git rebase`.
+You can find it at: https://git-rebase.io/[]
+====
+
 ==== The Nuclear Option: filter-branch
 
 There is another history-rewriting option that you can use if you need to rewrite a larger number of commits in some scriptable way -- for instance, changing your email address globally or removing a file from every commit.


### PR DESCRIPTION
## What happens when merging this pull-request:

- Create a new section in the book with a link to git-rebase.io
- Closes #1247
- Closes #1329

## Pros and cons of proposed change:

Pro:
- We skip the work of creating a new tutorial/sandbox for `git rebase`.
- No maintenance costs for maintaining a separate guide.
- The linked guide contains instructions on setting up a 'sandbox environment', where users can just noodle around and learn how `git rebase` works in depth.
- I think that after reading the guide, users will be equipped to use `git rebase` in their own workflow effectively.

Con:
- We have no control over the editorial tone of the guide.
- The site might go down/go out of date.
- Content of the guide is not saved in our own repository.

## Discussion:

I've had a lot of time to learn and use `git rebase`, and have opened some (lengthy) issues in the past (#1247 and #1329) on how to improve the ProGit2 teaching material for `git rebase`.
I've come to the conclusion that we could just link to the great guide made by Drew DeVault on git-rebase.io and be done with this annoying HonkingGoose :smile: :sparkle: