### PR TITLE
Change dead link within section on git within Visual Studio

### DIFF
--- a/book/A-git-in-other-environments/sections/visualstudio.asc
+++ b/book/A-git-in-other-environments/sections/visualstudio.asc
@@ -22,4 +22,4 @@ image::images/vs-2.png[The ``Home'' view for a Git repository in Visual Studio]
 
 Visual Studio now has a powerful task-focused UI for Git.
 It includes a linear history view, a diff viewer, remote commands, and many other capabilities.
-For complete documentation of this feature (which doesn't fit here), go to http://msdn.microsoft.com/en-us/library/hh850437.aspx[].
+For more on using Git within Visual Studio go to: https://docs.microsoft.com/en-us/azure/devops/repos/git/command-prompt?view=azure-devops[].


### PR DESCRIPTION
The link that's changed in this commit is dead.

I went to: https://docs.microsoft.com/en-us/visualstudio/windows/?view=vs-2019
to see where the docs for using git with the current version of Visual Studio 2019 can be found.
The site has a section with tasks, when I click on Version control, it takes me to:
https://docs.microsoft.com/en-us/azure/devops/repos/?view=azure-devops

On the azure dev-ops page they have a section called **Get started with Git or GitHub**. That section contains information about using git with Visual studio or from the command line. 
Those sections look like this:
https://docs.microsoft.com/en-us/azure/devops/repos/git/gitquickstart?view=azure-devops&tabs=visual-studio

I'm not sure what the best way to deal with this is, or what the best link should be. I've just pointed the link to the basic landing page after clicking on **Get started with Git or Github** from the Visual Studio 2019 docs.

Note that changing the link is not enough to get the section in order though: #1451 