### PR TITLE
Replace 'option' by more specific terms where needed for 'git log --pretty'

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -132,9 +132,9 @@ It also puts a summary of the information at the end.
 
 Another really useful option is `--pretty`.
 This option changes the log output to formats other than the default.
-A few prebuilt options are available for you to use.
-The `oneline` option prints each commit on a single line, which is useful if you're looking at a lot of commits.
-In addition, the `short`, `full`, and `fuller` options show the output in roughly the same format but with less or more information, respectively:
+A few prebuilt option values are available for you to use.
+The `oneline` value for this option prints each commit on a single line, which is useful if you're looking at a lot of commits.
+In addition, the `short`, `full`, and `fuller` values show the output in roughly the same format but with less or more information, respectively:
 
 [source,console]
 ----
@@ -144,7 +144,7 @@ ca82a6dff817ec66f44342007202690a93763949 Change version number
 a11bef06a3f659402fe7563abf99ad00de2209e6 Initial commit
 ----
 
-The most interesting option is `format`, which allows you to specify your own log output format.
+The most interesting option value is `format`, which allows you to specify your own log output format.
 This is especially useful when you're generating output for machine parsing -- because you specify the format explicitly, you know it won't change with updates to Git:(((log formatting)))
 
 [source,console]
@@ -155,28 +155,28 @@ ca82a6d - Scott Chacon, 6 years ago : Change version number
 a11bef0 - Scott Chacon, 6 years ago : Initial commit
 ----
 
-<<pretty_format>> lists some of the more useful options that `format` takes.
+<<pretty_format>> lists some of the more useful specifiers that `format` takes.
 
 [[pretty_format]]
-.Useful options for `git log --pretty=format`
+.Useful specifiers for `git log --pretty=format`
 [cols="1,4",options="header"]
 |================================
-| Option   | Description of Output
-| `%H`     | Commit hash
-| `%h`     | Abbreviated commit hash
-| `%T`     | Tree hash
-| `%t`     | Abbreviated tree hash
-| `%P`     | Parent hashes
-| `%p`     | Abbreviated parent hashes
-| `%an`    | Author name
-| `%ae`    | Author email
-| `%ad`    | Author date (format respects the --date=option)
-| `%ar`    | Author date, relative
-| `%cn`    | Committer name
-| `%ce`    | Committer email
-| `%cd`    | Committer date
-| `%cr`    | Committer date, relative
-| `%s`     | Subject
+| Specifier | Description of Output
+| `%H`      | Commit hash
+| `%h`      | Abbreviated commit hash
+| `%T`      | Tree hash
+| `%t`      | Abbreviated tree hash
+| `%P`      | Parent hashes
+| `%p`      | Abbreviated parent hashes
+| `%an`     | Author name
+| `%ae`     | Author email
+| `%ad`     | Author date (format respects the --date=option)
+| `%ar`     | Author date, relative
+| `%cn`     | Committer name
+| `%ce`     | Committer email
+| `%cd`     | Committer date
+| `%cr`     | Committer date, relative
+| `%s`      | Subject
 |================================
 
 You may be wondering what the difference is between _author_ and _committer_.
@@ -184,7 +184,7 @@ The author is the person who originally wrote the work, whereas the committer is
 So, if you send in a patch to a project and one of the core members applies the patch, both of you get credit -- you as the author, and the core member as the committer.
 We'll cover this distinction a bit more in <<ch05-distributed-git#ch05-distributed-git>>.
 
-The `oneline` and `format` options are particularly useful with another `log` option called `--graph`.
+The `oneline` and `format` option values are particularly useful with another `log` option called `--graph`.
 This option adds a nice little ASCII graph showing your branch and merge history:
 
 [source,console]
@@ -220,7 +220,7 @@ Those are only some simple output-formatting options to `git log` -- there are m
 | `--abbrev-commit` | Show only the first few characters of the SHA-1 checksum instead of all 40.
 | `--relative-date` | Display the date in a relative format (for example, ``2 weeks ago'') instead of using the full date format.
 | `--graph`         | Display an ASCII graph of the branch and merge history beside the log output.
-| `--pretty`        | Show commits in an alternate format. Options include oneline, short, full, fuller, and format (where you specify your own format).
+| `--pretty`        | Show commits in an alternate format. Option values include oneline, short, full, fuller, and format (where you specify your own format).
 | `--oneline`       | Shorthand for `--pretty=oneline --abbrev-commit` used together.
 |================================
 


### PR DESCRIPTION
Another good finding by @mo-gul: currently, everything related to `--pretty` is called option. This is not ideal for distinguishing the option from its values and the format specifiers. To resolve, I suggest the following naming scheme:

- Option: e.g. `--pretty`, `--stat`
- Option value: e.g. `short`, `full` after `--pretty=`
- [Format specifier](http://www.cplusplus.com/reference/cstdio/printf/): e.g. `%H`, `%T` in `--pretty=format:""`

I've implemented my suggestion for the section related to `--pretty`. I didn't check the entire book; we might want to align other places for consistency.