### PR TITLE
Change references of 'pu' to 'seen'

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -343,7 +343,7 @@ Then, when the codebase on that branch is stable and passes tests, you merge it 
 ===== Large-Merging Workflows
 
 (((workflows, "merging (large)")))
-The Git project has four long-running branches: `master`, `next`, and `pu` (proposed updates) for new work, and `maint` for maintenance backports.
+The Git project has four long-running branches: `master`, `next`, and `seen` (formerly 'pu' -- proposed updates) for new work, and `maint` for maintenance backports.
 When new work is introduced by contributors, it's collected into topic branches in the maintainer's repository in a manner similar to what we've described (see <<merwf_f>>).
 At this point, the topics are evaluated to determine whether they're safe and ready for consumption or whether they need more work.
 If they're safe, they're merged into `next`, and that branch is pushed up so everyone can try the topics integrated together.
@@ -352,10 +352,10 @@ If they're safe, they're merged into `next`, and that branch is pushed up so eve
 .Managing a complex series of parallel contributed topic branches
 image::images/large-merges-1.png[Managing a complex series of parallel contributed topic branches]
 
-If the topics still need work, they're merged into `pu` instead.
+If the topics still need work, they're merged into `seen` instead.
 When it's determined that they're totally stable, the topics are re-merged into `master`.
-The `next` and `pu` branches are then rebuilt from the `master`.
-This means `master` almost always moves forward, `next` is rebased occasionally, and `pu` is rebased even more often:
+The `next` and `seen` branches are then rebuilt from the `master`.
+This means `master` almost always moves forward, `next` is rebased occasionally, and `seen` is rebased even more often:
 
 .Merging contributed topic branches into long-term integration branches
 image::images/large-merges-2.png[Merging contributed topic branches into long-term integration branches]

--- a/images/large-merges-2.svg
+++ b/images/large-merges-2.svg
@@ -52,7 +52,7 @@
    <path id="path6741" transform="translate(690,171)" d="m9 16h58v1h-58v4l-9-4.5 9-4.5z" style="fill:#8f8981"/>
    <g id="g6749" transform="translate(714,171)" style="fill-rule:evenodd;fill:none">
     <rect id="rect6743" width="67" height="33" style="fill:#f44d27"/>
-    <text id="text6747" font-size="12px" font-weight="700" style="fill:#979797;font-family:'Source Code Pro';font-size:12px;font-weight:700;text-anchor:middle"><tspan id="tspan6745" x="33.5" y="20" style="fill:#f0f0f0">pu</tspan></text>
+    <text id="text6747" font-size="12px" font-weight="700" style="fill:#979797;font-family:'Source Code Pro';font-size:12px;font-weight:700;text-anchor:middle"><tspan id="tspan6745" x="33.5" y="20" style="fill:#f0f0f0">seen</tspan></text>
    </g>
   </g>
   <g id="Line-2-+-ref-9" transform="translate(690,216)" style="fill-rule:evenodd;fill:none">


### PR DESCRIPTION
Fixes #1447 

Ok. So, I've updated references of 'pu' to 'seen'. I've mentioned that it was previously called 'pu' in one place as it has served the Git community for 15 years. So, I think it deserves a mention for some more time.

There are still 2 references to 'pu' left:
1. The following reference in the "Long-running branches" section of Chapter 3 "Git Branching".
    > Some larger projects also have a `proposed` or `pu` (proposed updates) branch that has integrated branches that may not be ready to go into the `next` or `master` branch.

    I'm not particularly convinced about changing that as its not a direct reference to the Git project's branch. 
2. In 'images/merging-workflows-2.png'. This one is a direct reference to the Git project's branch and should be changed. I'm not sure how to go about doing that, though.

I went ahead and rename the reference in the, yet to be used, SVG image with hopes that it would be useful. I see that there's #1288 about using SVG instead of the PNG images. If that would be merged soon, I think the changes in this PR are enough :) If not, let me know how the PNG image should be updated.