### PR TITLE
Add note: how to set the pull.rebase variable

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -129,8 +129,7 @@ Running `git pull` generally fetches data from the server you originally cloned 
 
 [NOTE]
 ====
-From git version 2.27 onward:
-`git pull` will give a warning if the pull.rebase variable is not set.
+From git version 2.27 onward, `git pull` will give a warning if the `pull.rebase` variable is not set.
 Git will keep warning you until you set the variable.
 
 If you want the default behavior of git (fast-forward if possible, else create a merge commit):

--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -127,6 +127,19 @@ If your current branch is set up to track a remote branch (see the next section 
 This may be an easier or more comfortable workflow for you; and by default, the `git clone` command automatically sets up your local `master` branch to track the remote `master` branch (or whatever the default branch is called) on the server you cloned from.
 Running `git pull` generally fetches data from the server you originally cloned from and automatically tries to merge it into the code you're currently working on.
 
+[NOTE]
+====
+From git version 2.27 onward:
+`git pull` will give a warning if the pull.rebase variable is not set.
+Git will keep warning you until you set the variable.
+
+If you want the default behavior of git (fast-forward if possible, else create a merge commit):
+`git config --global pull.rebase "false"`
+
+If you want to rebase when pulling:
+`git config --global pull.rebase "true"`
+====
+
 [[_pushing_remotes]]
 ==== Pushing to Your Remotes
 


### PR DESCRIPTION
From git version 2.27 onward `git pull` will give a warning if the pull.rebase variable is not set.
You can stop git complaining on every pull by setting the variable.
This pull-request adds a note with help on how to set the variable.

This new behavior for git is documented in the release notes for git 2.27:
https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.27.0.txt

---

I checked the book for the first occurrence of `git pull` and put the note there.
If there's a better place for the note, please say so, and I'll move the note to that place instead. 😄 