### PR TITLE
Changes to move from master to main as our default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: bundler
 before_install:
 - bundle install
 after_success:
-- script/tag_on_master
+- script/tag_on_main
 script: bundle exec rake book:build
 env:
   secure: "O+YCTDgLfCYAJjjOv2sApDRV5NJe6pkhiYIkORFuf2flO8HE72fEtDRpSWh1vulnIH6AjRK2jH7C8qA3MVbUO8D0io+Ha+vnbMXIp1JPCptcJNEkJrW13VTR66SWOzsgLp3mCrIC+YdE2JoYWGcnDsRMQwdnrWnxBzSOd22ZKzU="
@@ -25,7 +25,7 @@ deploy:
     secure: "l3XdupX6dT48IoTieJXrd7Yx8+KhiR2QYrNrDzT6RKxA7UyXGSP/axsVerg7OjKfIHWZgDJRVzcc2RswE+Xjw9sOY8r2h2q9uCwj8G0EqtFbtgGK0La5LB0euh0tNJN8GLFj1OdSZGY7dWWK88GXeHCua2WSify0V79R4ClIM+s="
 branches:
   only:
-  - master
+  - main
   - /^2\.1(\.\d+)+$/
 
 notifications:

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -86,7 +86,7 @@ Please refer to the [Travis documentation](https://docs.travis-ci.com/) for more
 
 ### Setting up your repository for continuous integration
 
-Travis CI works by scanning your project's root directory for a file named `.travis.yml` and following the 'recipe' that it contains. The good news is: there's already a working `.travis.yml` file in the Pro Git 2 source [here](https://raw.githubusercontent.com/progit/progit2-pub/master/travis.yml).
+Travis CI works by scanning your project's root directory for a file named `.travis.yml` and following the 'recipe' that it contains. The good news is: there's already a working `.travis.yml` file in the Pro Git 2 source [here](https://raw.githubusercontent.com/progit/progit2-pub/main/travis.yml).
 Copy that file, and put it in your working directory. Commit the .yml file and push it to your translation repository; that should fire up a compilation and a check of the book's contents.
 
 ## Setting up a publication chain for e-books

--- a/atlas.json
+++ b/atlas.json
@@ -1,5 +1,5 @@
 {
-  "branch": "master",
+  "branch": "main",
   "files": [
     "book/cover.html",
     "LICENSE.asc",

--- a/script/tag_on_main
+++ b/script/tag_on_main
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# This is for running on Travis. It automatically tags any merge to Master as a release in the 2.1.x series.
-if [[ $TRAVIS_PULL_REQUEST != 'false' || "$TRAVIS_BRANCH" != 'master' ]]; then
+# This is for running on Travis. It automatically tags any merge to Main as a release in the 2.1.x series.
+if [[ $TRAVIS_PULL_REQUEST != 'false' || "$TRAVIS_BRANCH" != 'main' ]]; then
   # Don't run on pull requests
-  echo 'This only runs on a merge to master.'
+  echo 'This only runs on a merge to main.'
   exit 0
 fi
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Change Travis CI and use the renamed script
- Rename the script that Travis CI runs
- Change link in translating documentation
- Change reference to master in atlas.json

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

GitHub will make moving over from `master` to `main` easier later this year, so we might want to hold off until then.
I do think that the changes in this pull-request will probably still be necessary, even if we let GitHub do some things automatically.

Helps with #1463, but does not automatically close it, because more work is needed after the merge:

- Run trough all items listed in the #1463 issue checklist.
- After merging this pull-request, and verifying that everything still works the default branch for the repository will need to be set to the `main` branch in the GitHub repo settings.

I'm keeping all changes within one commit, so that we can use a simple `git revert` on this big change if necessary.