### PR TITLE
Change link to ssh key generation guide

### DIFF
--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -54,4 +54,4 @@ mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx
 NrRFi9wrf+M7Q== schacon@mylaptop.local
 ----
 
-For a more in-depth tutorial on creating an SSH key on multiple operating systems, see the GitHub guide on SSH keys at https://help.github.com/articles/generating-ssh-keys[].
+For a more in-depth tutorial on creating an SSH key on multiple operating systems, see the GitHub guide on SSH keys at https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent[].


### PR DESCRIPTION
The domain for the GitHub docs has moved to `docs.github.com`.
Following the old link redirects to the [general SSH help page](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh), instead of a page specific to generating the SSH key.

This pull-requests makes the link point to the specific help page on "Generating a new SSH key and adding it to the ssh-agent".
