### PR TITLE
Change link to GitHub docs

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -58,7 +58,7 @@ If there is no project for your language, you can start your own translation.
 
 Base your work on the second edition of the book, available [here](https://github.com/progit/progit2). To do so:
  1. Pick the correct [ISO 639 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for your language.
- 1. Create a [GitHub organization](https://help.github.com/articles/creating-a-new-organization-from-scratch/), for example: `progit2-[your code]` on GitHub.
+ 1. Create a [GitHub organization](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/creating-a-new-organization-from-scratch), for example: `progit2-[your code]` on GitHub.
  1. Create a project ``progit2``.
  1. Copy the structure of progit/progit2 (this project) in your project and start translating.
 


### PR DESCRIPTION
Clicking the old link redirects you to the link that's in this pull-request.
This pull-request replaces the old link with the new link directly, instead of relying on the redirect.