### PR TITLE
Make commit name consistent

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -139,7 +139,7 @@ When you save and exit the editor, Git rewinds you back to the last commit in th
 [source,console]
 ----
 $ git rebase -i HEAD~3
-Stopped at f7f3f6d... changed my name a bit
+Stopped at f7f3f6d... Change my name a bit
 You can amend the commit now, with
 
        git commit --amend


### PR DESCRIPTION
The example commit `f7f3f6d Change my name a bit` had a different message in one of the sections