### PR TITLE
Create section: your default branch name after git init

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -84,6 +84,18 @@ You may find, if you don't setup your editor like this, you get into a really co
 An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
+==== Your default branch name
+
+By default Git will create a branch called _master_ when you create a new repository with `git init`.
+From Git version 2.28 onwards, you can set a different name for the initial branch.
+
+To set _main_ as the default branch name do:
+
+[source,console]
+----
+$ git config --global init.defaultBranch main
+----
+
 ==== Checking Your Settings
 
 If you want to check your configuration settings, you can use the `git config --list` command to list all the settings Git can find at that point:


### PR DESCRIPTION
From Git 2.28 onwards you can change the default branch that Git will create when making a new repo with `git init`.
This pull-request adds a section in the first-time-setup part of the book, explaining how to set a different default branch.
I've chosen to use _main_ in the text, as that is what GitHub/Gitlab, and probably us as well, will be migrating towards.

Merging this pull-request also helps with https://github.com/progit/progit2/issues/1462#issuecomment-658827236

**EDIT:**
I did a search for mentions of `git init`, and found multiple places where we could/should reference this new section on changing the default branch name. I'm not sure where I should put links though...