### PR TITLE
Add tip section with link to git-send-email.io

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -785,6 +785,11 @@ References: <y>
 Result: OK
 ----
 
+[TIP]
+====
+For help on confuring your system and email, more tips and tricks, and a sandbox to send a trial patch via email, go to [git-send-email.io](https://git-send-email.io/).
+====
+
 ==== Summary
 
 In this section, we covered multiple workflows, and talked about the differences between working as part of a small team on closed-source projects vs contributing to a big public project.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add tip with a link to https://git-send-email.io/ in the _Contribution to the Public Project over Email_ part of the book

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

This website gives help on configuring your system (what packages to install on your Linux distribution), tells you how to configure your email client, and has a "sandbox repo" that you can target for your very first Git email patch. There are also extra tips and tricks.

I think this is a good match for what this section of the book is about. First you explain the high level overview of how things work, and give some examples in the book. And then the reader can read the tip, go to the website and give the whole shebang a try.

I think this section of the book makes the most sense. I you disagree, feel free to tell me where you want this tip, and I'll move it.