### PR TITLE
Update Git's detached HEAD help message

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -263,16 +263,22 @@ If you want to view the versions of files a tag is pointing to, you can do a `gi
 [source,console]
 ----
 $ git checkout v2.0.0
-Note: checking out 'v2.0.0'.
+Note: switching to 'v2.0.0'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
 state without impacting any branches by performing another checkout.
 
 If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -b with the checkout command again. Example:
+do so (now or later) by using -c with the switch command. Example:
 
-  git checkout -b <new-branch>
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at 99ada87... Merge pull request #89 from schacon/appendix-final
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Update Git's detached HEAD help message, as it now uses `git switch` instead of `git checkout` to help users get back to a previous HEAD state.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

From at least Git version 2.25.1, the detached HEAD advice text is changed. It now uses `git switch` instead of `git checkout`.

I searched for `detached HEAD` in the whole book and this is the only place where the Git command-line output is shown.

After merging, this would be the only place in the book where `git switch` is used.
@ben, do you want me to make a pull-request for a section explaining `git switch`?