### PR TITLE
Add v before version number for consistency

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -276,7 +276,7 @@ do so (now or later) by using -b with the checkout command again. Example:
 
 HEAD is now at 99ada87... Merge pull request #89 from schacon/appendix-final
 
-$ git checkout 2.0-beta-0.1
+$ git checkout v2.0-beta-0.1
 Previous HEAD position was 99ada87... Merge pull request #89 from schacon/appendix-final
 HEAD is now at df3f601... Add atlas.json and cover image
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add v before version number for consistency

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Throughout the tagging section we prepend any version numbers with "v", this commit ensures that we're consistent throughout. This also closes issue #852 that found some inconsistencies with the way we use tags.

Fixes #852