### PR TITLE
Link to more precise "What is Git" page in section 3.1 ("Branches in a Nutshell")

### DIFF
--- a/book/01-introduction/sections/what-is-git.asc
+++ b/book/01-introduction/sections/what-is-git.asc
@@ -1,3 +1,4 @@
+[[_what_is_git]]
 === What is Git?
 
 So, what is Git in a nutshell?

--- a/book/03-git-branching/sections/nutshell.asc
+++ b/book/03-git-branching/sections/nutshell.asc
@@ -3,13 +3,13 @@
 
 To really understand the way Git does branching, we need to take a step back and examine how Git stores its data.
 
-As you may remember from <<ch01-getting-started#ch01-getting-started>>, Git doesn't store data as a series of changesets or differences, but instead as a series of _snapshots_.
+As you may remember from <<ch01-getting-started#_what_is_git>>, Git doesn't store data as a series of changesets or differences, but instead as a series of _snapshots_.
 
 When you make a commit, Git stores a commit object that contains a pointer to the snapshot of the content you staged.
 This object also contains the author's name and email address, the message that you typed, and pointers to the commit or commits that directly came before this commit (its parent or parents): zero parents for the initial commit, one parent for a normal commit, and multiple parents for a commit that results from a merge of two or more branches.
 
 To visualize this, let's assume that you have a directory containing three files, and you stage them all and commit.
-Staging the files computes a checksum for each one (the SHA-1 hash we mentioned in <<ch01-getting-started#ch01-getting-started>>), stores that version of the file in the Git repository (Git refers to them as _blobs_), and adds that checksum to the staging area:
+Staging the files computes a checksum for each one (the SHA-1 hash we mentioned in <<ch01-getting-started#_what_is_git>>), stores that version of the file in the Git repository (Git refers to them as _blobs_), and adds that checksum to the staging area:
 
 [source,console]
 ----


### PR DESCRIPTION
[Section 3.1, "Branches in a Nutshell"](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) talks about snapshots and hashes, and refers to [this page](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) for more info on them. These topics don't appear on that page however. The author is probably referring to [section 1.3, "What is Git"](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F). This page is from the same chapter as is currently linked, but I think a more precise link would help the casual reader more.

This PR changes the link to point to section 1.3, "What is Git", instead of to the entire chapter, which takes the reader to section 1.1, "About Version Control".

- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add ID (`[[_what_is_git]]`) to section 1.3
- Link to this ID in section 3.1
