### PR TITLE
Fix invalid style for listing caution block

### DIFF
--- a/book/03-git-branching/sections/branch-management.asc
+++ b/book/03-git-branching/sections/branch-management.asc
@@ -77,10 +77,10 @@ $ git branch --no-merged master
 ==== Changing a branch name
 
 [CAUTION]
-----
+====
 Do not rename branches that are still in use by other collaborators.
 Do not rename a branch like master/main/mainline without having read the section "Changing the master branch name".
-----
+====
 
 Suppose you have a branch that is called _bad-branch-name_ and you want to change it to _corrected-branch-name_, while keeping all history.
 You also want to change the branch name on the remote (GitHub, GitLab, other server).


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fix invalid style for listing a caution block

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

I created the section on how to migrate a branch from `master` to `main` in  #1476, and added a caution block. I did not use the correct style of block, therefore the caution block was not rendering properly. This pull request fixes the issue.

Also I have now been able to get the Asciidoctor toolchain working! So I have actually verified this myself on the .html and .pdf output. :tada: :clinking_glasses: :partying_face: 