### PR TITLE
Explain missing .mobi builds in readme

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -15,7 +15,8 @@ See link:TRANSLATING.md[the translating document] for more information.
 == How To Generate the Book
 
 You can generate the e-book files manually with Asciidoctor.
-If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
+We used to be able to build .mobi files (Kindle), but cannot do so now, see #1496 for more information.
+If you run the following you _may_ actually get HTML, Epub and PDF output files:
 
 ----
 $ bundle install
@@ -24,8 +25,6 @@ Converting to HTML...
  -- HTML output at progit.html
 Converting to EPub...
  -- Epub output at progit.epub
-Converting to Mobi (kf8)...
- -- Mobi output at progit.mobi
 Converting to PDF...
  -- PDF output at progit.pdf
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add new sentence explaining missing .mobi builds.
- Remove .mobi from list of output files
- Remove .mobi from bundle exec rake book:build example

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

I think it's good to mention that we are not building any .mobi (Kindle) files directly in the readme. That way new contributors are not confused when they try to do the listed commands, and don't get the .mobi output files.

Related issue: #1496, and related pull: #1497.