### PR TITLE
Add note on PowerShell in Revision Selection 

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -180,6 +180,22 @@ Running `git show HEAD@{2.months.ago}` will show you the matching commit only if
 If you have a UNIX or Linux background, you can think of the reflog as Git's version of shell history, which emphasizes that what's there is clearly relevant only for you and your ``session'', and has nothing to do with anyone else who might be working on the same machine.
 ====
 
+[NOTE]
+.Escaping brackets in PowerShell
+====
+
+On Windows in `powershell.exe`, `{` and `}` are special characters and needs to be treated differently.
+You can either escape them with a backtick ` or put the commit reference in quotes:
+
+[source,console]
+----
+$ git show HEAD@{0}     # will NOT work on Windows
+$ git show HEAD@`{0`}   # OK
+$ git show "HEAD@{0}"   # OK
+----
+
+====
+
 ==== Ancestry References
 
 The other main way to specify a commit is via its ancestry.

--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -181,11 +181,11 @@ If you have a UNIX or Linux background, you can think of the reflog as Git's ver
 ====
 
 [NOTE]
-.Escaping brackets in PowerShell
+.Escaping braces in PowerShell
 ====
 
-On Windows in `powershell.exe`, `{` and `}` are special characters and needs to be treated differently.
-You can either escape them with a backtick ` or put the commit reference in quotes:
+When using PowerShell on Windows, braces like `{` and `}` are special characters and must be escaped.
+You can escape them with a backtick ` or put the commit reference in quotes:
 
 [source,console]
 ----

--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -184,12 +184,12 @@ If you have a UNIX or Linux background, you can think of the reflog as Git's ver
 .Escaping braces in PowerShell
 ====
 
-When using PowerShell on Windows, braces like `{` and `}` are special characters and must be escaped.
+When using PowerShell, braces like `{` and `}` are special characters and must be escaped.
 You can escape them with a backtick ` or put the commit reference in quotes:
 
 [source,console]
 ----
-$ git show HEAD@{0}     # will NOT work on Windows
+$ git show HEAD@{0}     # will NOT work
 $ git show HEAD@`{0`}   # OK
 $ git show "HEAD@{0}"   # OK
 ----


### PR DESCRIPTION

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add note on escaping curly braces in PowerShell when doing revision selection

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing a issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
I've been struggling with the revision selection syntax `HEAD@{...}` and finally found out it's because of curly braces special meaning in PowerShell. 

I noticed the NOTE on special handling of caret in cmd.exe on Windows. A similar note about curly braces in PowerShell would have saved me some time and I hope to save fellow developers some time by adding in such a note.