### PR TITLE
Add tip: use verbose CLI flags for shared scripts

### DIFF
--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -124,3 +124,8 @@ The `post-receive` hook runs after the entire process is completed and can be us
 It takes the same stdin data as the `pre-receive` hook.
 Examples include emailing a list, notifying a continuous integration server, or updating a ticket-tracking system – you can even parse the commit messages to see if any tickets need to be opened, modified, or closed.
 This script can't stop the push process, but the client doesn't disconnect until it has completed, so be careful if you try to do anything that may take a long time.
+
+[TIP]
+====
+If you're writing a script/hook that others will need to read, prefer the long versions of command-line flags; six months from now you'll thank us.
+====


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add tip: use verbose CLI flags for shared scripts

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Implements one of the wanted changes for issue #720:
> Put a note somewhere which says "if you're writing a script that others will need to read, prefer the long versions of command-line flags; six months from now you'll thank us."
