### PR TITLE
add example for "git log -- path"

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -262,7 +262,12 @@ $ git log -S function_name
 
 The last really useful option to pass to `git log` as a filter is a path.
 If you specify a directory or file name, you can limit the log output to commits that introduced a change to those files.
-This is always the last option and is generally preceded by double dashes (`--`) to separate the paths from the options.
+This is always the last option and is generally preceded by double dashes (`--`) to separate the paths from the options:
+
+[source,console]
+----
+$ git log -- path/to/file
+----
 
 In <<limit_options>> we'll list these and a few other common options for your reference.
 


### PR DESCRIPTION
Signed-off-by: Junjie Yuan <yuan@junjie.pro>

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- add example for "git log -- path"

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
```text
diff --git a/book/02-git-basics/sections/viewing-history.asc b/book/02-git-basics/sections/viewing-history.asc
index 0c3b796..72a5117 100644
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -262,7 +262,12 @@ $ git log -S function_name
 
 The last really useful option to pass to `git log` as a filter is a path.
 If you specify a directory or file name, you can limit the log output to commits that introduced a change to those files.
-This is always the last option and is generally preceded by double dashes (`--`) to separate the paths from the options.
+This is always the last option and is generally preceded by double dashes (`--`) to separate the paths from the options:
+
+[source,console]
+----
+$ git log -- path/to/file
+----
 
 In <<limit_options>> we'll list these and a few other common options for your reference.
 ```