### PR TITLE
Add tip to point to the official GitHub CLI tool

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -49,6 +49,13 @@ This is basically the Integration Manager workflow covered in <<ch05-distributed
 
 Let's walk through an example of proposing a change to an open source project hosted on GitHub using this flow.
 
+[TIP]
+====
+You can use the official *GitHub CLI* tool instead of the GitHub web interface for most things.
+The tool can be used on Windows, MacOS, and Linux systems.
+Go to the https://cli.github.com/[GitHub CLI homepage] for installation instructions and the manual.
+====
+
 ===== Creating a Pull Request
 
 Tony is looking for code to run on his Arduino programmable microcontroller and has found a great program file on GitHub at https://github.com/schacon/blink[].


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add tip to point to the official GitHub CLI tool

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Fixes #1530 

The GitHub CLI lets you do your GitHub work from within the command line.
GitHub has just released version 1.0, and so we can "recommend" it to our readers.

I think this is a logical place for the tip. If you want me to move it, let me know. :wink: 

For more information read the [GitHub blog post announcing GitHub CLI 1.0](https://github.blog/2020-09-17-github-cli-1-0-is-now-available/) and go to the [GitHub CLI project page](https://cli.github.com/).