### PR TITLE
Fix warning about `git restore` command

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -229,7 +229,7 @@ Changes to be committed:
 
 [IMPORTANT]
 =====
-It's important to understand that `git restore --staged <file>` is a dangerous command.
+It's important to understand that `git restore <file>` is a dangerous command.
 Any local changes you made to that file are gone -- Git just replaced that file with the most recently-committed version.
 Don't ever use this command unless you absolutely know that you don't want those unsaved local changes.
 =====


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Remove the `--staged` flag in the `git restore` warning

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #456
-->
It seems like the command that throwing away your local work is `git restore <file>` instead of `git restore --staged <file>`.

See #1533 to get more context.
Fixes #1533 
