### PR TITLE
Escape tilde to fix HEAD~~~ presented as HEAD~

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -282,7 +282,7 @@ Date:   Fri Nov 7 13:47:59 2008 -0500
     Ignore *.gem
 ----
 
-This can also be written `HEAD~~~`, which again is the first parent of the first parent of the first parent:
+This can also be written `HEAD\~~~`, which again is the first parent of the first parent of the first parent:
 
 [source,console]
 ----


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fixed \`\~\~\~\` presented as subscript tilde.

## Context

I noticed that \~\~\~ is presented as subscript tilde on git-scm site for some reason:

<img width="636" alt="Screenshot 2020-11-16 at 12 43 01" src="https://user-images.githubusercontent.com/107447/99238385-b700d080-280a-11eb-8875-ae24c226ea2a.png">
