### PR TITLE
Fix formatting issue

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -580,7 +580,7 @@ The history with the revert commit looks like this:
 .History after `git revert -m 1`
 image::images/undomerge-revert.png[History after `git revert -m 1`]
 
-The new commit `^M` has exactly the same contents as `C6`, so starting from here it's as if the merge never happened, except that the now-unmerged commits are still in `HEAD`'s history.
+The new commit `^M` has exactly the same contents as `C6`, so starting from here it's as if the merge never happened, except that the now-unmerged commits are still in `HEAD`’s history.
 Git will get confused if you try to merge `topic` into `master` again:
 
 [source,console]


### PR DESCRIPTION
Asciidoctor documentation suggests solution to properly render a possessive monospaced phrase by using [unconstrained formatting](https://asciidoctor.org/docs/user-manual/#unconstrained-formatting-edge-cases).
However, this approach does not work when one more monospaced phrase follows [in the same paragraph](https://gist.github.com/yugaego/edcef321c3e4a7c4f59d7756d7ef4042).
The simplest workaround was suggested by the Asciidoctor project lead Dan Allen.

**Before:**
PDF
<img width="1056" alt="before-pdf" src="https://user-images.githubusercontent.com/296460/99890182-440db480-2c65-11eb-90de-11232d9e8a7a.png">

HTML
<img width="1023" alt="before-html" src="https://user-images.githubusercontent.com/296460/99890183-48d26880-2c65-11eb-890b-8a67f0c54abd.png">

EPUB
<img width="593" alt="before-epub" src="https://user-images.githubusercontent.com/296460/99890189-5d166580-2c65-11eb-93da-5b9a2c71f2ba.png">


**After:**
PDF
<img width="1075" alt="after-pdf" src="https://user-images.githubusercontent.com/296460/99890192-67d0fa80-2c65-11eb-866c-78d8a9d74539.png">

HTML
<img width="1020" alt="after-html" src="https://user-images.githubusercontent.com/296460/99890194-6dc6db80-2c65-11eb-963b-dd9aadbb5709.png">

EPUB
<img width="584" alt="after-epub" src="https://user-images.githubusercontent.com/296460/99890220-b088b380-2c65-11eb-881e-4620c62ad0f0.png">



<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

