### PR TITLE
Small rewording change inside Rewriting History

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -56,7 +56,7 @@ $ git commit --amend --no-edit
 ==== Changing Multiple Commit Messages
 
 To modify a commit that is farther back in your history, you must move to more complex tools.
-Git doesn't have a modify-history tool, but you can use the rebase tool to rebase a series of commits onto the HEAD that were originally based on instead of moving them to another one.
+Git doesn't have a modify-history tool, but you can use the rebase tool to rebase a series of commits onto the HEAD that they were originally based on instead of moving them to another one.
 With the interactive rebase tool, you can then stop after each commit you want to modify and change the message, add files, or do whatever you wish.
 You can run rebase interactively by adding the `-i` option to `git rebase`.
 You must indicate how far back you want to rewrite commits by telling the command which commit to rebase onto.

--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -56,7 +56,7 @@ $ git commit --amend --no-edit
 ==== Changing Multiple Commit Messages
 
 To modify a commit that is farther back in your history, you must move to more complex tools.
-Git doesn't have a modify-history tool, but you can use the rebase tool to rebase a series of commits onto the HEAD they were originally based on instead of moving them to another one.
+Git doesn't have a modify-history tool, but you can use the rebase tool to rebase a series of commits onto the HEAD that were originally based on instead of moving them to another one.
 With the interactive rebase tool, you can then stop after each commit you want to modify and change the message, add files, or do whatever you wish.
 You can run rebase interactively by adding the `-i` option to `git rebase`.
 You must indicate how far back you want to rewrite commits by telling the command which commit to rebase onto.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
A small typo fix within the Rewriting History section, changing "they" to "that" in the below sentence:
> To modify a commit that is farther back in your history, you must move to more complex tools. Git doesn’t have a modify-history tool, but you can use the rebase tool to rebase a series of commits onto the HEAD they were originally based on instead of moving them to another one.

<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
