### PR TITLE
Use -L option in curl command to follow redirect

### DIFF
--- a/book/10-git-internals/sections/maintenance.asc
+++ b/book/10-git-internals/sections/maintenance.asc
@@ -192,7 +192,7 @@ First, add a large object to your history:
 
 [source,console]
 ----
-$ curl https://www.kernel.org/pub/software/scm/git/git-2.1.0.tar.gz > git.tgz
+$ curl -L https://www.kernel.org/pub/software/scm/git/git-2.1.0.tar.gz > git.tgz
 $ git add git.tgz
 $ git commit -m 'Add git tarball'
 [master 7b30847] Add git tarball


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Use -L option in curl command to follow redirect returned by www.kernel.org. Otherwise, the file you are testing with is not the ~5MB git.tgz, but a 168 byte HTML page informing you about the redirect.

## Context

Everything under https://www.kernel.org/pub/ seems to 301 (moved permanently) redirect to https://mirrors.edge.kernel.org/pub/. So the other option is to change the URL instead of adding the `-L` curl option. However, the www.kernel.org homepage still links to them as https://www.kernel.org/pub/, so it isn't clear to me what the most stable URL is, which is why I went with the -L.
