### PR TITLE
fetch original repository before use

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -521,14 +521,16 @@ You can automate this work with a bit of configuration:
 [source,console]
 ----
 $ git remote add progit https://github.com/progit/progit2.git <1>
-$ git branch --set-upstream-to=progit/master master <2>
-$ git config --local remote.pushDefault origin <3>
+$ git fetch progit <2>
+$ git branch --set-upstream-to=progit/master master <3>
+$ git config --local remote.pushDefault origin <4>
 ----
 
 <1> Add the source repository and give it a name.
     Here, I have chosen to call it `progit`.
-<2> Set your `master` branch to fetch from the `progit` remote.
-<3> Define the default push repository to `origin`.
+<2> Get a reference on progit's branches, in particular `master`.
+<3> Set your `master` branch to fetch from the `progit` remote.
+<4> Define the default push repository to `origin`.
 
 Once this is done, the workflow becomes much simpler:
 


### PR DESCRIPTION
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- added the `git fetch <repository>` command before we can use &lt;repository&gt;.

## Context

When you fork a repository and want your fork update-to-date, you can add the original repository to the remote list.
But before you can configure your `master` branch follow `<repository>/master` branch, it is required to first fetch the remote to get the `<repository>/master` branch.