### PR TITLE
Check for github-actions updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: "daily" # Checks on Monday trough Friday.
 
+  # Maintain GitHub Action runners
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily" # Checks on Monday trough Friday.
+
     # Set default reviewer and labels
     reviewers:
       - "ben"


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Check for GitHub Action updates daily (Monday through Friday)

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Dependabot can check for GitHub Action runner updates.

You only need this PR **after** you've migrated to GitHub Actions for your CI.
Feel free to close this PR if you decide to migrate to some other CI provider.
Just wanted to get this ready in case it's needed.

Feel free to tell me to tone down the frequency of the checks, I can also use `weekly` or `monthly`.