### PR TITLE
Make wording in refs.asc clearer

### DIFF
--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -205,5 +205,5 @@ ca82a6dff817ec66f44342007202690a93763949
 ----
 
 Remote references differ from branches (`refs/heads` references) mainly in that they're considered read-only.
-You can `git checkout` to one, but Git won't point HEAD at one, so you'll never update it with a `commit` command.
+You can `git checkout` to one, but Git won't symolically reference HEAD to one, so you'll never update it with a `commit` command.
 Git manages them as bookmarks to the last known state of where those branches were on those servers.


### PR DESCRIPTION
When reading this line I was very confused.  It didn't sound like it made sense.  So I checked out a remote ref, ran `cat .git/HEAD`, and lo and behold it did "point" to the same thing that the remote branch pointed to.

I played around with it a little bit more and realized the difference between checking out a local and remote reference is that checking out a local reference sets `.git/HEAD` to a SYMBOLIC ref, while checking out a remote reference sets it to the exact commit.

I think the current language is *technically* correct, because "Git won't point HEAD at one" means it won't point HEAD to the remote reference itself (since "one" means the remote reference, not the commit).  So I'm not saying the current wording is bad, just that it confused me, so it might confuse others

Also, when you say "you'll never update it" and "read-only" of course you are referring to the remote reference, but a naive reader like myself may thing you're referring to HEAD.  And if I checkout a remote reference then commit a change I will update HEAD

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- 

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
