### PR TITLE
Replace 3 instances of "VCS systems" with "VCSs"

### DIFF
--- a/book/01-introduction/sections/about-version-control.asc
+++ b/book/01-introduction/sections/about-version-control.asc
@@ -44,7 +44,7 @@ However, this setup also has some serious downsides.
 The most obvious is the single point of failure that the centralized server represents.
 If that server goes down for an hour, then during that hour nobody can collaborate at all or save versioned changes to anything they're working on.
 If the hard disk the central database is on becomes corrupted, and proper backups haven't been kept, you lose absolutely everything -- the entire history of the project except whatever single snapshots people happen to have on their local machines.
-Local VCS systems suffer from this same problem -- whenever you have the entire history of the project in a single place, you risk losing everything.
+Local VCSs suffer from this same problem -- whenever you have the entire history of the project in a single place, you risk losing everything.
 
 ==== Distributed Version Control Systems
 

--- a/book/02-git-basics/sections/getting-a-repository.asc
+++ b/book/02-git-basics/sections/getting-a-repository.asc
@@ -57,7 +57,7 @@ At this point, you have a Git repository with tracked files and an initial commi
 ==== Cloning an Existing Repository
 
 If you want to get a copy of an existing Git repository -- for example, a project you'd like to contribute to -- the command you need is `git clone`.
-If you're familiar with other VCS systems such as Subversion, you'll notice that the command is "clone" and not "checkout".
+If you're familiar with other VCSs such as Subversion, you'll notice that the command is "clone" and not "checkout".
 This is an important distinction -- instead of getting just a working copy, Git receives a full copy of nearly all data that the server has.
 Every version of every file for the history of the project is pulled down by default when you run `git clone`.
 In fact, if your server disk gets corrupted, you can often use nearly any of the clones on any client to set the server back to the state it was in when it was cloned (you may lose some server-side hooks and such, but all the versioned data would be there -- see <<ch04-git-on-the-server#_getting_git_on_a_server>> for more details).

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -579,7 +579,7 @@ This command removes all files whose names end with a `~`.
 ==== Moving Files
 
 (((files, moving)))
-Unlike many other VCS systems, Git doesn't explicitly track file movement.
+Unlike many other VCSs, Git doesn't explicitly track file movement.
 If you rename a file in Git, no metadata is stored in Git that tells it you renamed the file.
 However, Git is pretty smart about figuring that out after the fact -- we'll deal with detecting file movement a bit later.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- The redundant phrase "VCS systems" should be replaced with "VCSs" in three locations in the text (sections 1.1, 2.1, 2.2).

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
"VCSs" as a plural abbreviation is established in the Introduction and used elsewhere in the book.