### PR TITLE
Fix reported typo issue in Chapter 2

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -27,7 +27,7 @@ If you run this command directly after a clone, you should see something like th
 $ git status
 On branch master
 Your branch is up-to-date with 'origin/master'.
-nothing to commit, working directory clean
+nothing to commit, working tree clean
 ----
 
 This means you have a clean working directory; in other words, none of your tracked files are modified.

--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -179,7 +179,7 @@ $ git remote show origin
 ----
 
 It lists the URL for the remote repository as well as the tracking branch information.
-The command helpfully tells you that if you're on the `master` branch and you run `git pull`, it will automatically merge in the `master` branch on the remote after it fetches all the remote references.
+The command helpfully tells you that if you're on the `master` branch and you run `git pull`, it will automatically merge in the `master` branch on the local after it fetches all the remote references.
 It also lists all the remote references it has pulled down.
 
 That is a simple example you're likely to encounter.

--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -179,7 +179,7 @@ $ git remote show origin
 ----
 
 It lists the URL for the remote repository as well as the tracking branch information.
-The command helpfully tells you that if you're on the `master` branch and you run `git pull`, it will automatically merge in the `master` branch on the local after it fetches all the remote references.
+The command helpfully tells you that if you're on the `master` branch and you run `git pull`, it will automatically merge the remote's `master` branch into the local one after it has been fetched.
 It also lists all the remote references it has pulled down.
 
 That is a simple example you're likely to encounter.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
Fix reported typo in Chapter 2 of the book:
  1. `merge the remote's master into the local` (#1565)
  2. `nothing to commit, working directory -> nothing to commit, working tree` (#1559)

## Context

Fixes #1565 
Fixes #1559 