### PR TITLE
Refactor book:build task

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -29,6 +29,26 @@ Converting to PDF...
  -- PDF output at progit.pdf
 ----
 
+If you only want to generate only one of supported formats (HTML, Epub, or PDF), do one of the following:
+
+To generate HTML book:
+
+----
+$ bundle exec rake book:build_html
+----
+
+To generate Epub book:
+
+----
+$ bundle exec rake book:build_epub
+----
+
+To generate PDF book:
+
+----
+$ bundle exec rake book:build_pdf
+----
+
 == Signaling an Issue
 
 Before signaling an issue, please check that there isn't already a similar one in the bug tracking system.

--- a/Rakefile
+++ b/Rakefile
@@ -21,18 +21,31 @@ namespace :book do
       puts "Generating contributors list"
       `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
 
+
+
+    end
+  end
+
+  desc 'build HTML format'
+  task :build_html do
       puts "Converting to HTML..."
       `bundle exec asciidoctor #{params} -a data-uri progit.asc`
       puts " -- HTML output at progit.html"
 
       exec_or_raise('htmlproofer --check-html progit.html')
+  end
 
+  desc 'build Epub format'
+  task :build_epub do
       puts "Converting to EPub..."
       `bundle exec asciidoctor-epub3 #{params} progit.asc`
       puts " -- Epub output at progit.epub"
 
       exec_or_raise('epubcheck progit.epub')
+  end
 
+  desc 'build Mobi format'
+  task :build_mobi do
       # Commented out the .mobi file creation because the kindlegen dependency is not available.
       # For more information on this see: #1496.
       # This is a (hopefully) temporary fix until upstream asciidoctor-epub3 is fixed and we can offer .mobi files again.
@@ -41,12 +54,20 @@ namespace :book do
       # `bundle exec asciidoctor-epub3 #{params} -a ebook-format=kf8 progit.asc`
       # puts " -- Mobi output at progit.mobi"
 
+      # FIXME: If asciidoctor-epub3 supports Mobi again, uncomment these
+      # lines below
+      puts "Converting to Mobi isn't supported yet."
+      puts "For more information see issue #1496 at https://github.com/progit/progit2/issues/1496."
+      exit(127)
+  end
+
+  desc 'build PDF format'
+  task :build_pdf do
       puts "Converting to PDF... (this one takes a while)"
       `bundle exec asciidoctor-pdf #{params} progit.asc 2>/dev/null`
       puts " -- PDF output at progit.pdf"
-
-    end
   end
+
 end
 
 task :default => "book:build"

--- a/Rakefile
+++ b/Rakefile
@@ -6,16 +6,18 @@ namespace :book do
     end
   end
 
+  # Variables referenced for build
+  version_string = ENV['TRAVIS_TAG'] || `git describe --tags`.chomp
+  if version_string.empty?
+    version_string = '0'
+  end
+  date_string = Time.now.strftime("%Y-%m-%d")
+  params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
+
   desc 'build basic book formats'
   task :build do
 
     begin
-      version_string = ENV['TRAVIS_TAG'] || `git describe --tags`.chomp
-      if version_string.empty?
-        version_string = '0'
-      end
-      date_string = Time.now.strftime("%Y-%m-%d")
-      params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
       puts "Generating contributors list"
       `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,14 @@ namespace :book do
     end
   end
 
+  desc 'build basic book formats (for ci)'
+  task :ci => [:build_html, :build_epub, :build_pdf] do
+    begin
+        # Run check, but don't ignore any errors
+        Rake::Task["book:check"].invoke
+    end
+  end
+
   desc 'generate contributors list'
   file 'book/contributors.txt' do
       puts "Generating contributors list"

--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,8 @@ namespace :book do
         puts "Hash on header of contributors list (#{header_hash}) does not match the current HEAD (#{current_head_hash}), refreshing"
         `rm book/contributors.txt`
         # Reenable and invoke task again
-        Rake::Task["book/contributors.txt"].reenable
-        Rake::Task["book/contributors.txt"].invoke
+        Rake::Task['book/contributors.txt'].reenable
+        Rake::Task['book/contributors.txt'].invoke
       end
     end
   end
@@ -40,7 +40,7 @@ namespace :book do
   task :build => [:build_html, :build_epub, :build_pdf] do
     begin
         # Run check
-        Rake::Task["book:check"].invoke
+        Rake::Task['book:check'].invoke
 
         # Rescue to ignore checking errors
         rescue => e
@@ -52,7 +52,7 @@ namespace :book do
   desc 'build basic book formats (for ci)'
   task :ci => [:build_html, :build_epub, :build_pdf] do
       # Run check, but don't ignore any errors
-      Rake::Task["book:check"].invoke
+      Rake::Task['book:check'].invoke
   end
 
   desc 'generate contributors list'

--- a/Rakefile
+++ b/Rakefile
@@ -101,8 +101,10 @@ namespace :book do
 
             # Rescue if file not found
             rescue Errno::ENOENT => e
-            puts e.message
-            puts "Error removing files (ignored)"
+              begin
+                  puts e.message
+                  puts "Error removing files (ignored)"
+              end
         end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -15,13 +15,7 @@ namespace :book do
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
 
   desc 'build basic book formats'
-  task :build do
-
-    begin
-
-
-    end
-  end
+  task :build => [:build_html, :build_epub, :build_pdf]
 
   desc 'generate contributors list'
   file 'book/contributors.txt' do

--- a/Rakefile
+++ b/Rakefile
@@ -65,6 +65,22 @@ namespace :book do
       puts " -- PDF output at progit.pdf"
   end
 
+  desc 'Clean all generated files'
+  task :clean do
+    begin
+        puts "Removing generated files"
+
+        FileList['book/contributors.txt', 'progit.html', 'progit.epub', 'progit.pdf'].each do |file|
+            rm file
+
+            # Rescue if file not found
+            rescue Errno::ENOENT => e
+            puts e.message
+            puts "Error removing files (ignored)"
+        end
+    end
+  end
+
 end
 
 task :default => "book:build"

--- a/Rakefile
+++ b/Rakefile
@@ -29,10 +29,8 @@ namespace :book do
 
   desc 'build basic book formats (for ci)'
   task :ci => [:build_html, :build_epub, :build_pdf] do
-    begin
-        # Run check, but don't ignore any errors
-        Rake::Task["book:check"].invoke
-    end
+      # Run check, but don't ignore any errors
+      Rake::Task["book:check"].invoke
   end
 
   desc 'generate contributors list'
@@ -83,12 +81,10 @@ namespace :book do
 
   desc 'Check generated books'
   task :check => [:build_html, :build_epub] do
-    begin
-        puts "Checking generated books"
+      puts "Checking generated books"
 
-        exec_or_raise('htmlproofer --check-html progit.html')
-        exec_or_raise('epubcheck progit.epub')
-    end
+      exec_or_raise('htmlproofer --check-html progit.html')
+      exec_or_raise('epubcheck progit.epub')
   end
 
   desc 'Clean all generated files'

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,17 @@ namespace :book do
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
 
   desc 'build basic book formats'
-  task :build => [:build_html, :build_epub, :build_pdf, :check]
+  task :build => [:build_html, :build_epub, :build_pdf] do
+    begin
+        # Run check
+        Rake::Task["book:check"].invoke
+
+        # Rescue to ignore checking errors
+        rescue => e
+        puts e.message
+        puts "Error when checking books (ignored)"
+    end
+  end
 
   desc 'generate contributors list'
   file 'book/contributors.txt' do

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ namespace :book do
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
 
   desc 'build basic book formats'
-  task :build => [:build_html, :build_epub, :build_pdf]
+  task :build => [:build_html, :build_epub, :build_pdf, :check]
 
   desc 'generate contributors list'
   file 'book/contributors.txt' do
@@ -29,7 +29,6 @@ namespace :book do
       `bundle exec asciidoctor #{params} -a data-uri progit.asc`
       puts " -- HTML output at progit.html"
 
-      exec_or_raise('htmlproofer --check-html progit.html')
   end
 
   desc 'build Epub format'
@@ -38,7 +37,6 @@ namespace :book do
       `bundle exec asciidoctor-epub3 #{params} progit.asc`
       puts " -- Epub output at progit.epub"
 
-      exec_or_raise('epubcheck progit.epub')
   end
 
   desc 'build Mobi format'
@@ -63,6 +61,16 @@ namespace :book do
       puts "Converting to PDF... (this one takes a while)"
       `bundle exec asciidoctor-pdf #{params} progit.asc 2>/dev/null`
       puts " -- PDF output at progit.pdf"
+  end
+
+  desc 'Check generated books'
+  task :check => [:build_html, :build_epub] do
+    begin
+        puts "Checking generated books"
+
+        exec_or_raise('htmlproofer --check-html progit.html')
+        exec_or_raise('epubcheck progit.epub')
+    end
   end
 
   desc 'Clean all generated files'

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ namespace :book do
   if version_string.empty?
     version_string = '0'
   end
-  date_string = Time.now.strftime("%Y-%m-%d")
+  date_string = Time.now.strftime('%Y-%m-%d')
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
 
   desc 'build basic book formats'
@@ -23,7 +23,7 @@ namespace :book do
         # Rescue to ignore checking errors
         rescue => e
         puts e.message
-        puts "Error when checking books (ignored)"
+        puts 'Error when checking books (ignored)'
     end
   end
 
@@ -35,23 +35,23 @@ namespace :book do
 
   desc 'generate contributors list'
   file 'book/contributors.txt' do
-      puts "Generating contributors list"
+      puts 'Generating contributors list'
       `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
   end
 
   desc 'build HTML format'
   task :build_html => 'book/contributors.txt' do
-      puts "Converting to HTML..."
+      puts 'Converting to HTML...'
       `bundle exec asciidoctor #{params} -a data-uri progit.asc`
-      puts " -- HTML output at progit.html"
+      puts ' -- HTML output at progit.html'
 
   end
 
   desc 'build Epub format'
   task :build_epub => 'book/contributors.txt' do
-      puts "Converting to EPub..."
+      puts 'Converting to EPub...'
       `bundle exec asciidoctor-epub3 #{params} progit.asc`
-      puts " -- Epub output at progit.epub"
+      puts ' -- Epub output at progit.epub'
 
   end
 
@@ -67,21 +67,21 @@ namespace :book do
 
       # FIXME: If asciidoctor-epub3 supports Mobi again, uncomment these
       # lines below
-      puts "Converting to Mobi isn't supported yet."
-      puts "For more information see issue #1496 at https://github.com/progit/progit2/issues/1496."
+      puts 'Converting to Mobi is not supported yet.'
+      puts 'For more information see issue #1496 at https://github.com/progit/progit2/issues/1496.'
       exit(127)
   end
 
   desc 'build PDF format'
   task :build_pdf => 'book/contributors.txt' do
-      puts "Converting to PDF... (this one takes a while)"
+      puts 'Converting to PDF... (this one takes a while)'
       `bundle exec asciidoctor-pdf #{params} progit.asc 2>/dev/null`
-      puts " -- PDF output at progit.pdf"
+      puts ' -- PDF output at progit.pdf'
   end
 
   desc 'Check generated books'
   task :check => [:build_html, :build_epub] do
-      puts "Checking generated books"
+      puts 'Checking generated books'
 
       exec_or_raise('htmlproofer --check-html progit.html')
       exec_or_raise('epubcheck progit.epub')
@@ -90,7 +90,7 @@ namespace :book do
   desc 'Clean all generated files'
   task :clean do
     begin
-        puts "Removing generated files"
+        puts 'Removing generated files'
 
         FileList['book/contributors.txt', 'progit.html', 'progit.epub', 'progit.pdf'].each do |file|
             rm file
@@ -99,7 +99,7 @@ namespace :book do
             rescue Errno::ENOENT => e
               begin
                   puts e.message
-                  puts "Error removing files (ignored)"
+                  puts 'Error removing files (ignored)'
               end
         end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ namespace :book do
   end
   date_string = Time.now.strftime('%Y-%m-%d')
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"
+  header_hash = `git rev-parse --short HEAD`.strip
 
   desc 'build basic book formats'
   task :build => [:build_html, :build_epub, :build_pdf] do
@@ -36,7 +37,8 @@ namespace :book do
   desc 'generate contributors list'
   file 'book/contributors.txt' do
       puts 'Generating contributors list'
-      `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
+      `echo "Contributors as of #{header_hash}:\n" > book/contributors.txt`
+      `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 >> book/contributors.txt`
   end
 
   desc 'build HTML format'

--- a/Rakefile
+++ b/Rakefile
@@ -18,16 +18,19 @@ namespace :book do
   task :build do
 
     begin
-      puts "Generating contributors list"
-      `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
-
 
 
     end
   end
 
+  desc 'generate contributors list'
+  file 'book/contributors.txt' do
+      puts "Generating contributors list"
+      `git shortlog -s | grep -v -E "(Straub|Chacon|dependabot)" | cut -f 2- | column -c 120 > book/contributors.txt`
+  end
+
   desc 'build HTML format'
-  task :build_html do
+  task :build_html => 'book/contributors.txt' do
       puts "Converting to HTML..."
       `bundle exec asciidoctor #{params} -a data-uri progit.asc`
       puts " -- HTML output at progit.html"
@@ -36,7 +39,7 @@ namespace :book do
   end
 
   desc 'build Epub format'
-  task :build_epub do
+  task :build_epub => 'book/contributors.txt' do
       puts "Converting to EPub..."
       `bundle exec asciidoctor-epub3 #{params} progit.asc`
       puts " -- Epub output at progit.epub"
@@ -45,7 +48,7 @@ namespace :book do
   end
 
   desc 'build Mobi format'
-  task :build_mobi do
+  task :build_mobi => 'book/contributors.txt' do
       # Commented out the .mobi file creation because the kindlegen dependency is not available.
       # For more information on this see: #1496.
       # This is a (hopefully) temporary fix until upstream asciidoctor-epub3 is fixed and we can offer .mobi files again.
@@ -62,7 +65,7 @@ namespace :book do
   end
 
   desc 'build PDF format'
-  task :build_pdf do
+  task :build_pdf => 'book/contributors.txt' do
       puts "Converting to PDF... (this one takes a while)"
       `bundle exec asciidoctor-pdf #{params} progit.asc 2>/dev/null`
       puts " -- PDF output at progit.pdf"

--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,6 @@ namespace :book do
       # FIXME: If asciidoctor-epub3 supports Mobi again, uncomment these lines below
       puts "Converting to Mobi isn't supported yet."
       puts "For more information see issue #1496 at https://github.com/progit/progit2/issues/1496."
->>>>>>> fork/build-task-refactor
       exit(127)
   end
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

This PR refactors monolithic `book:build` task into several smaller tasks:
  1. `book/contributors.txt` file task: generates contributors list required to build book formats
  2. `book:build_html` - build HTML format
  3. `book:build_epub` - build Epub format
  4. `book:build_pdf` - build PDF format
  5. `book:check` - check HTML and Epub

This also add convenience tasks:
  1. `book:clean` - clean artifacts (contributors list and books)
  2. `book:ci` - build books with checking enforced (not ignored), targeted for CI.

Note: The CI doesn't execute `book:ci`, but still running `book:build` instead. Discussions are welcome whether the CI should switch to `book:ci` or not.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
Fixes #1595 