### PR TITLE
Update usage snippet and code explanation for git credential-read-only

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -174,7 +174,7 @@ include::../git-credential-read-only[]
 <3> This loop reads from stdin until the first blank line is reached.
     The inputs are stored in the `known` hash for later reference.
 <4> This loop reads the contents of the storage file, looking for matches.
-    If the protocol and host from `known` match this line, the program prints the results to stdout and exits.
+    If the protocol, host, and username from `known` match this line, the program prints the results to stdout and exits.
 
 We'll save our helper as `git-credential-read-only`, put it somewhere in our `PATH` and mark it executable.
 Here's what an interactive session looks like:

--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -184,6 +184,7 @@ Here's what an interactive session looks like:
 $ git credential-read-only --file=/mnt/shared/creds get
 protocol=https
 host=mygithost
+username=bob
 
 protocol=https
 host=mygithost


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

This PR:
  1. Update usage snippet for `git credential-read-only` as the credential helper now requires `username` parameter
  2. Update code listing explanation to reflect `username` parameter requirement above

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
Fixes #1375 