### PR TITLE
Split of two dashes

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -136,7 +136,7 @@ You can see that the changes have been reverted.
 
 [IMPORTANT]
 =====
-It's important to understand that `git checkout -- <file>` is a dangerous command.
+It's important to understand that `git checkout \-- <file>` is a dangerous command.
 Any local changes you made to that file are gone -- Git just replaced that file with the most recently-committed version.
 Don't ever use this command unless you absolutely know that you don't want those unsaved local changes.
 =====


### PR DESCRIPTION
In file [progit2/book/02-git-basics/sections/undoing.asc](https://github.com/progit/progit2/blob/master/book/02-git-basics/sections/undoing.asc) two dashes were connected in one.

Screenshot:
![image](https://user-images.githubusercontent.com/7223702/107007306-64003f00-67a3-11eb-87a3-4e587d580e7f.png)


Decision was found from:
[https://github.com/SergeiKuznetsov/progit2-ru/commit/149801bfcb5a4bda5a324177172325e3b5f95efd](https://github.com/SergeiKuznetsov/progit2-ru/commit/149801bfcb5a4bda5a324177172325e3b5f95efd)