### PR TITLE
Fix lingering Markdown for git-send-email.io

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -787,7 +787,7 @@ Result: OK
 
 [TIP]
 ====
-For help on configuring your system and email, more tips and tricks, and a sandbox to send a trial patch via email, go to https://git-send-email.io/[git-send-email.io].
+For help on configuring your system and email, more tips and tricks, and a sandbox to send a trial patch via email, go to https://git-send-email.io[git-send-email.io^].
 ====
 
 ==== Summary

--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -787,7 +787,7 @@ Result: OK
 
 [TIP]
 ====
-For help on configuring your system and email, more tips and tricks, and a sandbox to send a trial patch via email, go to [git-send-email.io](https://git-send-email.io/).
+For help on configuring your system and email, more tips and tricks, and a sandbox to send a trial patch via email, go to https://git-send-email.io/[git-send-email.io].
 ====
 
 ==== Summary


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fix the link to <https://git-send-email.io> to use AsciiDoc syntax instead of Markdown.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
Builds on #1489 
