### PR TITLE
redirect bugs not for ProGit2 with config.yml file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,6 @@ assignees: ''
 <!-- * This bug is about the Pro Git book, version 2, English language. -->
 <!-- * This bug is about the book as found on the [website](https://www.git-scm.com/book/en/v2) or the pdf. -->
 <!-- * If you found an issue in the pdf/epub/mobi files, you've checked if the problem is also present in the Pro Git book on the [website](https://www.git-scm.com/book/en/v2). -->
-<!-- * This bug is **not** about a translation, if so please file a bug with the translation project. You can find a table of translation projects here: [progit2/TRANSLATING.md](https://github.com/progit/progit2/blob/master/TRANSLATING.md) -->
-<!-- * This bug is **not** about the git-scm.com site, if so please file a bug here: [git-scm.com/issues/new](https://github.com/git/git-scm.com/issues/new) -->
-<!-- * This bug is **not** about git the program itself, if so please file a bug here: [git-scm.com/community](https://git-scm.com/community) -->
-<!-- * This bug is **not** about Git for Windows, if so please file a bug here: [git-for-windows/git](https://github.com/git-for-windows/git). -->
 
 **Which version of the book is affected?**
 <!-- It's important for us to know if the problem is in the source or in the tooling for the pdf/epub/mobi files. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+contact_links:
+  - name: Translation bug
+    url: https://github.com/progit/progit2/blob/master/TRANSLATING.md
+    about: Refer to this table to find out where to report translation bugs.
+
+  - name: Report bugs for git-scm.com site
+    url: https://github.com/git/git-scm.com/issues/
+    about: Please report problems with the git-scm.com site here.
+
+  - name: Bug is about Git program itself
+    url: https://git-scm.com/community
+    about: Please report problems with the Git program here.
+
+  - name: Bug is about Git for Windows
+    url: https://github.com/git-for-windows/git/issues
+    about: Please report problems with Git for Windows here.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Use a `config.yml` file in the `ISSUE_TEMPLATES` folder which adds new buttons with links to the proper place to report certain bugs
- Remove "migrated" lines from the Markdown bug report template

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

This `config.yml` file adds extra links on the issue select screen on GitHub.
GitHub calls this screen the "issue template chooser".
The contact_links have a name, description and URL property.

[GitHub docs, configuring the template chooser](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)

Example of how the external links look on the screen (ignore the text for now, you can customize this):

![issue-template-chooser-from-pr](https://user-images.githubusercontent.com/34918129/107367514-ae552900-6adf-11eb-8910-403dadd2a70b.png)
See how you get a nice big `Open` button. 😄 
This way we can redirect bug reports that are not for the ProGit 2 project in a visual way, instead of relying on users reading a wall 
of Markdown commented text. 😉 