### PR TITLE
Use generic link to Dulwich website

### DIFF
--- a/book/B-embedding-git/sections/dulwich.asc
+++ b/book/B-embedding-git/sections/dulwich.asc
@@ -40,5 +40,4 @@ porcelain.log('.', max_entries=1)
 
 ==== Further Reading
 
- * The official API documentation is available at https://www.dulwich.io/docs/api/[].
- * Official tutorial at https://www.dulwich.io/docs/tutorial[] has many examples of how to do specific tasks with Dulwich.
+The API documentation, tutorial, and many examples of how to do specific tasks with Dulwich are available on the official website https://www.dulwich.io[].


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Due to errors on loading particular webpages from dulwich.io the HTML checker fails on each build. And it's better to use the main page only instead of the list of pages.
