### PR TITLE
Remove GitHub Desktop from installing Git section

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -65,12 +65,6 @@ Note that this is a project called Git for Windows, which is separate from Git i
 To get an automated installation you can use the https://chocolatey.org/packages/git[Git Chocolatey package].
 Note that the Chocolatey package is community maintained.
 
-Another easy way to get Git installed is by installing GitHub Desktop.
-The installer includes a command line version of Git as well as the GUI.
-It also works well with PowerShell, and sets up solid credential caching and sane CRLF settings.(((PowerShell)))(((CRLF)))(((credential caching)))
-We'll learn more about those things a little later, but suffice it to say they're things you want.
-You can download this from the https://desktop.github.com[GitHub Desktop website].
-
 ==== Installing from Source
 
 Some people may instead find it useful to install Git from source, because you'll get the most recent version.

--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -51,10 +51,6 @@ A macOS Git installer is maintained and available for download at the Git websit
 .Git macOS Installer
 image::images/git-osx-installer.png[Git macOS installer]
 
-You can also install it as part of the GitHub for macOS install.
-Their GUI Git tool has an option to install command line tools as well.
-You can download that tool from the GitHub for macOS website, at https://desktop.github.com[].
-
 ==== Installing on Windows
 
 There are also a few ways to install Git on Windows.(((Windows, installing)))


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

This PR removes GitHub Desktop from the installation instructions for getting Git on your machine. 

## Context

I'm the engineering manager for GitHub Desktop. We try to avoid confusion from people thinking that downloading Desktop is an easy way to also install Git. There's more context here about why we chose to avoid that for the current version: https://github.com/desktop/desktop/issues/3708#issuecomment-354665183
