### PR TITLE
Improve wording on issue select screen

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,12 +5,12 @@ contact_links:
 
   - name: Report bugs for git-scm.com site
     url: https://github.com/git/git-scm.com/issues/
-    about: Please report problems with the git-scm.com site here.
+    about: Please report problems with the git-scm.com site there.
 
   - name: Bug is about Git program itself
     url: https://git-scm.com/community
-    about: Please report problems with the Git program here.
+    about: Please report problems with the Git program there.
 
   - name: Bug is about Git for Windows
     url: https://github.com/git-for-windows/git/issues
-    about: Please report problems with Git for Windows here.
+    about: Please report problems with Git for Windows there.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Change word `here` -> `there`

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

I think the current wording is confusing to newcomers to the ProGit2 repository: see #1627.
The user probably meant to post at the Git for Windows repository, but somehow still ended up here. 😄 
We can all take a wrong turn somewhere, but we should still ensure that we're clear on where to go instead.

Feel free to suggest further improvements to the text, maybe we should be really explicit and say:
`Click on the "open" button next to this text to go to the right place to report your problem.`?