### PR TITLE
Clarify tree object example not a continuation of previous examples

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -126,7 +126,7 @@ The next type of Git object we'll examine is the _tree_, which solves the proble
 Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
 All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
 A single tree object contains one or more entries, each of which is the SHA-1 hash of a blob or subtree with its associated mode, type, and filename.
-For example, the most recent tree in a project may look something like this:
+For example, a repository (different from the one created in the previous section) may have a tree that looks something like:
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -126,7 +126,7 @@ The next type of Git object we'll examine is the _tree_, which solves the proble
 Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
 All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
 A single tree object contains one or more entries, each of which is the SHA-1 hash of a blob or subtree with its associated mode, type, and filename.
-For example, a repository (different from the one created in the previous section) may have a tree that looks something like:
+For example, let's say you have a project where the most-recent tree looks something like:
 
 [source,console]
 ----


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Alert readers who are following along in the shell that the next example does not use the repository that was just created.  
- 

## Context
Section 10.2: Git Objects begins with creating a new repository and explaining how blobs are added to it.  The active voice used throughout that section implies it is expected for readers to be following along within their own shell.  The next section, 10.2: Tree Objects, begins with an example which is not related to the previous examples.  The current wording is "most recent tree in **a project** may look something like this".  However, the project created in the previous section is a not a valid interpretation of "a project"; it does not yet have a tree.  As a result, readers may enter the command given into their shell and produce an unexpected result:

```
git cat-file -p master^^{tree}
fatal: Not a valid object name master^{tree}
```

The topic has just been introduced, so the reader has no understanding from which to make sense of the error.  Was it something they did?  Is it something else?  There is no way for them to know without already understanding the section.

Since the section then continues to use the previously created repository, it seems appropriate to alert readers of the exception in the first example.

This problem has been encountered previously in https://github.com/progit/progit2/issues/421 (fixes #421)

