### PR TITLE
Enable .mobi (Kindle) format again

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -15,8 +15,7 @@ See link:TRANSLATING.md[the translating document] for more information.
 == How To Generate the Book
 
 You can generate the e-book files manually with Asciidoctor.
-We used to be able to build .mobi files (Kindle), but cannot do so now, see #1496 for more information.
-If you run the following you _may_ actually get HTML, Epub and PDF output files:
+If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
 
 ----
 $ bundle install
@@ -25,11 +24,13 @@ Converting to HTML...
  -- HTML output at progit.html
 Converting to EPub...
  -- Epub output at progit.epub
+Converting to Mobi (kf8)...
+ -- Mobi output at progit.mobi
 Converting to PDF...
  -- PDF output at progit.pdf
 ----
 
-You can generate just one of the supported formats (HTML, EPUB, or PDF).
+You can generate just one of the supported formats (HTML, EPUB, mobi, or PDF).
 Use one of the following commands:
 
 To generate the HTML book:
@@ -42,6 +43,12 @@ To generate the EPUB book:
 
 ----
 $ bundle exec rake book:build_epub
+----
+
+To generate the mobi book:
+
+----
+$ bundle exec rake book:build_mobi
 ----
 
 To generate the PDF book:

--- a/Rakefile
+++ b/Rakefile
@@ -84,18 +84,9 @@ namespace :book do
 
   desc 'build Mobi format'
   task :build_mobi => 'book/contributors.txt' do
-      # Commented out the .mobi file creation because the kindlegen dependency is not available.
-      # For more information on this see: #1496.
-      # This is a (hopefully) temporary fix until upstream asciidoctor-epub3 is fixed and we can offer .mobi files again.
-
-      # puts "Converting to Mobi (kf8)..."
-      # `bundle exec asciidoctor-epub3 #{params} -a ebook-format=kf8 progit.asc`
-      # puts " -- Mobi output at progit.mobi"
-
-      # FIXME: If asciidoctor-epub3 supports Mobi again, uncomment these lines below
-      puts "Converting to Mobi isn't supported yet."
-      puts "For more information see issue #1496 at https://github.com/progit/progit2/issues/1496."
-      exit(127)
+      puts "Converting to Mobi (kf8)..."
+      `bundle exec asciidoctor-epub3 #{params} -a ebook-format=kf8 progit.asc`
+      puts " -- Mobi output at progit.mobi"
   end
 
   desc 'build PDF format'


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Enable `.mobi` (Kindle) format again
- Add references to mobi files back in README
- Add mobi rake build command to README

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Fixes #1528

`asciidoctor-epub3` has the Kindlegen dependency in it again, so we can enable mobi builds again. (https://github.com/progit/progit2/pull/1646#issuecomment-828968577)

Please check if this change alone is enough to get things working.

@slonopotamus @jnavila can you please check my work?