### PR TITLE
bash.asc | Warn about the version of the source code

### DIFF
--- a/book/A-git-in-other-environments/sections/bash.asc
+++ b/book/A-git-in-other-environments/sections/bash.asc
@@ -5,6 +5,9 @@ If you're a Bash user, you can tap into some of your shell's features to make yo
 Git actually ships with plugins for several shells, but it's not turned on by default.
 
 First, you need to get a copy of the `contrib/completion/git-completion.bash` file out of the Git source code.
+Make sure to get it from the version of the source code that corresponds to the version of Git your are using.
+You can find the version of Git you are using with the command `git version`.
+You can then select the corresponding tag on the Git source code, using `git checkout tags/vX.Y.Z`, where `vX.Y.Z` corresponds to the version of Git you are using.
 Copy it somewhere handy, like your home directory, and add this to your `.bashrc`:
 
 [source,console]

--- a/book/A-git-in-other-environments/sections/bash.asc
+++ b/book/A-git-in-other-environments/sections/bash.asc
@@ -4,11 +4,9 @@
 If you're a Bash user, you can tap into some of your shell's features to make your experience with Git a lot friendlier.
 Git actually ships with plugins for several shells, but it's not turned on by default.
 
-First, you need to get a copy of the `contrib/completion/git-completion.bash` file out of the Git source code.
-Make sure to get it from the version of the source code that corresponds to the version of Git your are using.
-You can find the version of Git you are using with the command `git version`.
-You can then select the corresponding tag on the Git source code, using `git checkout tags/vX.Y.Z`, where `vX.Y.Z` corresponds to the version of Git you are using.
-Copy it somewhere handy, like your home directory, and add this to your `.bashrc`:
+First, you need to get a copy of the completions file from the source code of the Git release you're using.
+Check your version by typing `git version`, then use `git checkout tags/vX.Y.Z`, where `vX.Y.Z` corresponds to the version of Git you are using.
+Copy the `contrib/completion/git-completion.bash` file somewhere handy, like your home directory, and add this to your `.bashrc`:
 
 [source,console]
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- When I followed the instructions with the "Git in Bash" [page](https://git-scm.com/book/en/v2/Appendix-A%3A-Git-in-Other-Environments-Git-in-Bash), it did not work directly for me. It took me some time to realize -- with the help of <https://stackoverflow.com/a/50919451/5028673>, thanks! -- that when I took the files `contrib/completion/git-completion.bash` and `contrib/completion/git-prompt.sh`, I took them from the `master` branch, while I was running an "older" version of Git. Thus, I was thinking that it would be useful to mention within the instructions to be careful about the version of the source code to use.

## Context

See above.

<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
