### PR TITLE
Revert "Enable .mobi (Kindle) format again"

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -15,7 +15,8 @@ See link:TRANSLATING.md[the translating document] for more information.
 == How To Generate the Book
 
 You can generate the e-book files manually with Asciidoctor.
-If you run the following you _may_ actually get HTML, Epub, Mobi and PDF output files:
+We used to be able to build .mobi files (Kindle), but cannot do so now, see #1496 for more information.
+If you run the following you _may_ actually get HTML, Epub and PDF output files:
 
 ----
 $ bundle install
@@ -24,13 +25,11 @@ Converting to HTML...
  -- HTML output at progit.html
 Converting to EPub...
  -- Epub output at progit.epub
-Converting to Mobi (kf8)...
- -- Mobi output at progit.mobi
 Converting to PDF...
  -- PDF output at progit.pdf
 ----
 
-You can generate just one of the supported formats (HTML, EPUB, mobi, or PDF).
+You can generate just one of the supported formats (HTML, EPUB, or PDF).
 Use one of the following commands:
 
 To generate the HTML book:
@@ -43,12 +42,6 @@ To generate the EPUB book:
 
 ----
 $ bundle exec rake book:build_epub
-----
-
-To generate the mobi book:
-
-----
-$ bundle exec rake book:build_mobi
 ----
 
 To generate the PDF book:

--- a/Rakefile
+++ b/Rakefile
@@ -84,9 +84,18 @@ namespace :book do
 
   desc 'build Mobi format'
   task :build_mobi => 'book/contributors.txt' do
-      puts "Converting to Mobi (kf8)..."
-      `bundle exec asciidoctor-epub3 #{params} -a ebook-format=kf8 progit.asc`
-      puts " -- Mobi output at progit.mobi"
+      # Commented out the .mobi file creation because the kindlegen dependency is not available.
+      # For more information on this see: #1496.
+      # This is a (hopefully) temporary fix until upstream asciidoctor-epub3 is fixed and we can offer .mobi files again.
+
+      # puts "Converting to Mobi (kf8)..."
+      # `bundle exec asciidoctor-epub3 #{params} -a ebook-format=kf8 progit.asc`
+      # puts " -- Mobi output at progit.mobi"
+
+      # FIXME: If asciidoctor-epub3 supports Mobi again, uncomment these lines below
+      puts "Converting to Mobi isn't supported yet."
+      puts "For more information see issue #1496 at https://github.com/progit/progit2/issues/1496."
+      exit(127)
   end
 
   desc 'build PDF format'


### PR DESCRIPTION
Reverts progit/progit2#1655

This PR is breaking the build on the `master` branch, so we're not releasing new files for any merged PRs.
I'd rather revert my bad change, and let somebody else try again.