### PR TITLE
Migrate from master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Translation bug
-    url: https://github.com/progit/progit2/blob/master/TRANSLATING.md
+    url: https://github.com/progit/progit2/blob/main/TRANSLATING.md
     about: Refer to this table to find out where to report translation bugs.
 
   - name: Report bugs for git-scm.com site

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->
 
 <!-- Mark the checkbox [X] or [x] if you agree with the item. -->
-- [ ] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
+- [ ] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
 - [ ] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).
 
 ## Changes

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,7 +2,7 @@ name: Pull Request Build
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,8 +1,8 @@
-name: Release on push to master
+name: Release on push to main
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   release:
@@ -34,5 +34,5 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ steps.compute-tag.outputs.tagname }}
-        commit: master
+        commit: main
         artifacts: './progit.epub,./progit.mobi,./progit.pdf,./progit.html'

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -76,7 +76,7 @@ On https://git-scm.com, the translations are divided into three categories. Once
 
 GitHub Actions is a [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) service that integrates with GitHub. GitHub Actions is used to ensure that a pull-request doesn't break the build or compilation. GitHub Actions can also provide compiled versions of the book.
 
-The configuration for GitHub Actions is contained in the `.github/workflows` directory, and if you bring in the `master` branch of the root repository you'll get them for free.
+The configuration for GitHub Actions is contained in the `.github/workflows` directory, and if you bring in the `main` branch of the root repository you'll get them for free.
 However, if you created your translation repo by _forking_ the root repo, there's an extra step you must complete (if you did not fork, you can skip this part).
 GitHub assumes that forks will be used to contribute to the repo from which they were forked, so you'll have to visit the "Actions" tab on your forked repo, and click the "I understand my workflows" button to allow the actions to run.
 

--- a/atlas.json
+++ b/atlas.json
@@ -1,5 +1,5 @@
 {
-  "branch": "master",
+  "branch": "main",
   "files": [
     "book/cover.html",
     "LICENSE.asc",


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Adjust workflow files
- Adjust links in some files on our repo (not strictly necessary, but nice to have anyways)
- Adjust `atlas.json`
- Adjust line in `TRANSLATING.md` that refers to the ProGit2 default branch

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

Well waiting on this has been very beneficial, as GitHub does most of the hard work automatically now. 😄 

Read the GitHub docs before starting: https://docs.github.com/en/github/administering-a-repository/managing-branches-in-your-repository/renaming-a-branch

Steps to migrate:

1. Review this PR, confirm this contains all the necessary changes in script files/rakefile/action workflow files.
2. Merge this PR.
3. Repository maintainer uses GitHub web interface to rename the `master` branch to `main` following the steps in the GitHub docs.
4. Done.

State of repository after merging this and renaming `master` -> `main`:

- Anybody who has forked `progit2` will get a message from GitHub telling them what they need to do to update their forks.
- Anybody who links to our current `master` branch will get redirected to the `main` branch automatically, with no breaking links/scripts on their end.
- GitHub will make sure all open PRs are targeting the `main` branch
- Dependabot will update its PRs to target `main` as well

Fixes #1463.