### PR TITLE
Fix quotes in "Rewriting history" section

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -124,7 +124,7 @@ It will start at the commit you specify on the command line (`HEAD~3`) and repla
 It lists the oldest at the top, rather than the newest, because that's the first one it will replay.
 
 You need to edit the script so that it stops at the commit you want to edit.
-To do so, change the word `pick' to the word `edit' for each of the commits you want the script to stop after.
+To do so, change the word "`pick`" to the word "`edit`" for each of the commits you want the script to stop after.
 For example, to modify only the third commit message, you change the file to look like this:
 
 [source,console]


### PR DESCRIPTION
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
- Quotation marks style is changed from grave+apostrophe to combination that is properly rendered as slanted double quotation marks as used in other parts of the book.

## Context
This is the only place in the book where this type of quotes were used. Also, grave in the Noto Serif font included with EPUB version of the book is combining, so this two words were rendered incorrectly:
![Screenshot_20210809-201914__01](https://user-images.githubusercontent.com/2412121/128747246-a0981a3f-150b-43a6-bc65-4092ed4597bb.jpg)