### PR TITLE
Add '--nofork' flag to vim example in Appendix C

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -66,7 +66,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Textmate |`git config --global core.editor "mate -w"`
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\TextPad 5\TextPad.exe' -m` (Also see note below)
 |UltraEdit (Windows 64-bit) | `git config --global core.editor Uedit32`
-|Vim |`git config --global core.editor "vim"`
+|Vim |`git config --global core.editor "vim --nofork"`
 |Visual Studio Code |`git config --global core.editor "code --wait"`
 |VSCodium (Free/Libre Open Source Software Binaries of VSCode) | `git config --global core.editor "codium --wait"`
 |WordPad |`git config --global core.editor '"C:\Program Files\Windows NT\Accessories\wordpad.exe"'"`


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

The `-f`/`--nofork` flag is suggested to be used "... when Vim is executed by a
program that will wait for the edit session to finish...." However, this flag
is only used when Vim has the GUI version, effectively no-op'ing when non-GUI
Vim. This mirrors the existing "--nofork" flag for the Windows `gvim` example.

## Context

I didn't see any prior issues/PRs related to this flag for `vim`.
This flag did fix a co-worker's issue, referenced in this SO question https://stackoverflow.com/questions/22699614/git-commit-messages-lost-by-vi (I've never personally encountered the issue).
As best I can tell, this flag exists regardless if the user's `vim` features a GUI. To be honest, I'm not clear if the flag does anything for just `vim` and only for `gvim`. 
Basing on https://github.com/vim/vim/blob/e29a27f6f8eef8f00d3c2d4cd9811d81cf3026b3/src/main.c#L2124-L2129 & https://github.com/vim/vim/blob/e29a27f6f8eef8f00d3c2d4cd9811d81cf3026b3/src/main.c#L2027-L2032 and `vim` man pages. 
I also went with `--nofork` over `-f` since I felt long flags are easier to discover. Best I can tell they're equivalent, even if the man page doesn't say so.
So, it seems safe to add and "follows" man page description. However, I could see it being considered extraneous if it does nothing for `vim` specifically. So figured I'd send up a PR just in case.