### PR TITLE
Use same style as zsh documentation

### DIFF
--- a/book/A-git-in-other-environments/sections/zsh.asc
+++ b/book/A-git-in-other-environments/sections/zsh.asc
@@ -28,8 +28,8 @@ autoload -Uz vcs_info
 precmd_vcs_info() { vcs_info }
 precmd_functions+=( precmd_vcs_info )
 setopt prompt_subst
-RPROMPT=\$vcs_info_msg_0_
-# PROMPT=\$vcs_info_msg_0_'%# '
+RPROMPT='${vcs_info_msg_0_}'
+# PROMPT='${vcs_info_msg_0_}%# '
 zstyle ':vcs_info:git:*' formats '%b'
 ----
 


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
Both the zsh manpage, and the documentation at https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#Version-Control-Information which is linked in the progit book talk about single quoted `'${vcs_info_msg_0_}'` instead of trying to escape the `\$`

## Context
Their syntax is less confusing if anyone ends up searching for more information in the documentation.