### PR TITLE
Modernize recommendation for credential store

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,9 +19,9 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an "`osxkeychain`" mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, macOS, or Linux, you can install a helper called "`Git Credential Manager Core.`"
+* If you're using Windows, macOS, or Linux, you can install a helper called "`Git Credential Manager.`"
   This uses platform-native data stores to control sensitive information.
-  It can be found at https://github.com/microsoft/Git-Credential-Manager-Core[].
+  It can be found at https://github.com/GitCredentialManager/git-credential-manager[].
 
 You can choose one of these methods by setting a Git configuration value:
 

--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,9 +19,9 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an "`osxkeychain`" mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, you can install a helper called "`Git Credential Manager for Windows.`"
-  This is similar to the "`osxkeychain`" helper described above, but uses the Windows Credential Store to control sensitive information.
-  It can be found at https://github.com/Microsoft/Git-Credential-Manager-for-Windows[].
+* If you're using Windows, macOS, or Linux, you can install a helper called "`Git Credential Manager Core.`"
+  This uses platform-native data stores to control sensitive information.
+  It can be found at https://github.com/microsoft/Git-Credential-Manager-Core[].
 
 You can choose one of these methods by setting a Git configuration value:
 

--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,9 +19,8 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an "`osxkeychain`" mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, macOS, or Linux, you can install a helper called "`Git Credential Manager.`"
+* If you're using Windows, macOS, or Linux, you can install a helper called https://github.com/GitCredentialManager/git-credential-manager["`Git Credential Manager`"].
   This uses platform-native data stores to control sensitive information.
-  It can be found at https://github.com/GitCredentialManager/git-credential-manager[].
 
 You can choose one of these methods by setting a Git configuration value:
 


### PR DESCRIPTION
GCM for Windows (along with GCM for macOS/Linux) has been replaced with the cross-platform GCM Core.

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Remove mention of "GCM for Windows", replace with "GCM Core".

## Context

GCM for Windows has been superseded GCM Core. GCM for Windows is deprecated and no longer supported.