### PR TITLE
Add mailto: property to email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 ## Reporting a security issue
 
-If you find any security issue or vulnerability, please email ben@straub.cc with your report.
+If you find any security issue or vulnerability, please email [ben@straub.cc](mailto:ben@straub.cc) with your report.
 
 Do not open a issue on the `progit/progit2` repository or discuss the vulnerability in public.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add `mailto:` property to email address

## Context

Made a Markdown link out of the email adress, and added the `mailto:` property.
This makes the client's browser open their preferred email program, so they can mail you right away.

Not fixing any existing issue with this.