### PR TITLE
Update message to be equal with later mentions

### DIFF
--- a/book/10-git-internals/sections/maintenance.asc
+++ b/book/10-git-internals/sections/maintenance.asc
@@ -68,7 +68,7 @@ First, let's review where your repository is at this point:
 [source,console]
 ----
 $ git log --pretty=oneline
-ab1afef80fac8e34258ff41fc1b867c702daa24b Modify repo a bit
+ab1afef80fac8e34258ff41fc1b867c702daa24b Modify repo.rb a bit
 484a59275031909e19aadb7c92262719cfcdf19a Create repo.rb
 1a410efbd13591db07496601ebc7a059dd55cfe9 Third commit
 cac0cab538b970a37ea1e769cbbde608743bc96d Second commit


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

commit message in `maintenance.asc` (chapter 10)
"Modify repo.rb a bit" gets used later on in the log outputs for that same commit, so the message should be equal.
