### PR TITLE
Update instructions for Windows GCM

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -19,9 +19,8 @@ Git has a few options provided in the box:
   The downside of this approach is that your passwords are stored in cleartext in a plain file in your home directory.
 * If you're using a Mac, Git comes with an "`osxkeychain`" mode, which caches credentials in the secure keychain that's attached to your system account.
   This method stores the credentials on disk, and they never expire, but they're encrypted with the same system that stores HTTPS certificates and Safari auto-fills.
-* If you're using Windows, you can install a helper called "`Git Credential Manager for Windows.`"
-  This is similar to the "`osxkeychain`" helper described above, but uses the Windows Credential Store to control sensitive information.
-  It can be found at https://github.com/Microsoft/Git-Credential-Manager-for-Windows[].
+* If you're using Windows, you can enable the *Git Credential Manager* feature when installing https://gitforwindows.org/[Git for Windows] or separately install https://github.com/GitCredentialManager/git-credential-manager/releases/latest[the latest GCM] as a standalone service.
+  This is similar to the "`osxkeychain`" helper described above, but uses the Windows Credential Store to control sensitive information. It can also serve credentials to WSL1 or WSL2. See https://github.com/GitCredentialManager/git-credential-manager#windows[GCM Install Instructions] for more information.
 
 You can choose one of these methods by setting a Git configuration value:
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

[Microsoft/Git-Credential-Manager-for-Windows](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) was archived on 2020 Sep 30 and it is no longer being maintained. 

> The cross-platform [Git Credential Manager Core (GCM Core)](https://aka.ms/gcmcore) is the official replacement.

Therefore, I have updated the documentation to reflect this fact and recommend instead that readers rely on  Git Credential Manager Core (GCM Core). 

## Context
#736
#583 
