### PR TITLE
Note that master is not always the default

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -84,6 +84,7 @@ You may find, if you don't setup your editor like this, you get into a really co
 An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
+[[_default_branch]]
 ==== Your default branch name
 
 By default Git will create a branch called _master_ when you create a new repository with `git init`.

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -36,6 +36,15 @@ Finally, the command tells you which branch you're on and informs you that it ha
 For now, that branch is always `master`, which is the default; you won't worry about it here.
 <<ch03-git-branching#ch03-git-branching>> will go over branches and references in detail.
 
+[NOTE]
+====
+GitHub changed the default branch name from `master` to `main` in mid-2020, and other Git hosts followed suit.
+So you may find that the default branch name in some newly created repositories is `main` and not `master`.
+In addition, the default branch name can be changed (as you have seen in <<ch01-getting-started#_default_branch>>), so you may see a different name for the default branch.
+
+However, Git itself still uses `master` as the default, so we will use it throughout the book.
+====
+
 Let's say you add a new file to your project, a simple `README` file.
 If the file didn't exist before, and you run `git status`, you see your untracked file like so:
 


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add an id to Ch01 > First-time Git Setup > Your default branch name.
- Add a note in Ch02 > Recording Changes to the Repository > Checking the Status of Your Files, directly after the paragraph that says:

  > Finally, the command tells you which branch you’re on and informs you that it has not diverged from the same branch on the server. For now, that branch is always `master`, which is the default; you won’t worry about it here.

  The note points out that remote repositories are likely to have a different default branch name.

## Context

GitHub in mid-2020 changed the default branch name from `master` to `main`, and so did other Git hosts.
And many developers use an even different default branch name like `dev` or `develop` or something else.

A beginner might be very confused when seeing a repo whose default branch is not `master`. So I think it worth pointing out that explicitly.

I mean, the book asserts that the default branch is always `master`, when explaining the `git status` output in a freshly cloned repo. That repo is [libgit2](https://github.com/libgit2/libgit2), whose default branch is `main`…
