### PR TITLE
Fix add/rm subcommand code highlighting

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -617,4 +617,4 @@ $ git add README
 
 Git figures out that it's a rename implicitly, so it doesn't matter if you rename a file that way or with the `mv` command.
 The only real difference is that `git mv` is one command instead of three -- it's a convenience function.
-More importantly, you can use any tool you like to rename a file, and address the add/rm later, before you commit.
+More importantly, you can use any tool you like to rename a file, and address the `add`/`rm` later, before you commit.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Adds code highlighting to the `add` and `rm` subcommands when explaining recording changes
