### PR TITLE
ch-10: avoid unnecessary mention update-index's --add

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -202,7 +202,7 @@ You'll now create a new tree with the second version of `test.txt` and a new fil
 [source,console]
 ----
 $ echo 'new file' > new.txt
-$ git update-index --add --cacheinfo 100644 \
+$ git update-index --cacheinfo 100644 \
   1f7a7a472abf3dd9643fd615f6da379c4acb3e3a test.txt
 $ git update-index --add new.txt
 ----


### PR DESCRIPTION
<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

The book clearly mentions that --add needs to be passed to 'git update-index'
only when the file is new to the index. When the second version of 'test.txt' is
added, the index know about the file already.

So, avoid passing the '--add' when adding the second version of 'test.txt'
