### PR TITLE
Submodules: update `git submodule update --remote` behaviour

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -262,7 +262,7 @@ From https://github.com/chaconinc/DbConnector
 Submodule path 'DbConnector': checked out 'd0354fc054692d3906c85c3af05ddce39a1c0644'
 ----
 
-This command will by default assume that you want to update the checkout to the `master` branch of the submodule repository.
+This command will by default assume that you want to update the checkout to the default branch of the remote submodule repository (the one pointed to by `HEAD` on the remote).
 You can, however, set this to something different if you want.
 For example, if you want to have the DbConnector submodule track that repository's ``stable'' branch, you can set it in either your `.gitmodules` file (so everyone else also tracks it), or just in your local `.git/config` file.
 Let's set it in the `.gitmodules` file:


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Since f0a96e8d4c (submodule: fall back to remote's HEAD for missing
remote.<name>.branch, 2020-06-24), which went into Git 2.28, 'git
submodule upadte --remote' does not default to using the 'master' branch
of the remote repository, but rather the remote repository's HEAD
branch.

Tweak the wording to reflect this behaviour change.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
Noticed while re-reading the chapter today.