### PR TITLE
Fix user.signingkey example

### DIFF
--- a/book/07-git-tools/sections/signing.asc
+++ b/book/07-git-tools/sections/signing.asc
@@ -29,7 +29,7 @@ Once you have a private key to sign with, you can configure Git to use it for si
 
 [source,console]
 ----
-$ git config --global user.signingkey 0A46826A
+$ git config --global user.signingkey 0A46826A!
 ----
 
 Now Git will use your key by default to sign tags and commits if you want.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Since the value of user.signingkey is passed unchanged to gpg's --local-user parameter, the fingerprint needs to be suffixed with an exclamation mark (!).
If a fingerprint is specified without an exclamation mark, it is simply ignored.

<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
