### PR TITLE
Use unconstrained formatting pairs for possessive monospace

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -298,7 +298,7 @@ Now, when you run `git archive` to create a tarball of your project, that direct
 
 ===== `export-subst`
 
-When exporting files for deployment you can apply `git log`'s formatting and keyword-expansion processing to selected portions of files marked with the `export-subst` attribute.
+When exporting files for deployment you can apply ``git log```'s formatting and keyword-expansion processing to selected portions of files marked with the ``export-subst`` attribute.
 
 For instance, if you want to include a file named `LAST_COMMIT` in your project, and have metadata about the last commit automatically injected into it when `git archive` runs, you can for example set up your `.gitattributes` and `LAST_COMMIT` files like this:
 

--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -172,7 +172,7 @@ int git_odb_backend_mine(git_odb_backend **backend_out, /*…*/)
 }
 ----
 
-The subtlest constraint here is that `my_backend_struct`'s first member must be a `git_odb_backend` structure; this ensures that the memory layout is what the Libgit2 code expects it to be.
+The subtlest constraint here is that ``my_backend_struct```'s first member must be a ``git_odb_backend`` structure; this ensures that the memory layout is what the Libgit2 code expects it to be.
 The rest of it is arbitrary; this structure can be as large or small as you need it to be.
 
 The initialization function allocates some memory for the structure, sets up the custom context, and then fills in the members of the `parent` structure that it supports.


### PR DESCRIPTION
See also:

https://docs.asciidoctor.org/asciidoc/latest/text/troubleshoot-unconstrained-formatting/#unconstrained-edge-cases
https://docs.asciidoctor.org/asciidoc/latest/text/quotation-marks-and-apostrophes/#possessive-monospace
https://docs.asciidoctor.org/asciidoc/latest/text/#unconstrained

Fixes #1644

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Uses different quoting style for formatting characters to allow correct escaping and printing. I found occurrences in two places (looking for ``` `'s```).

### Before

![export-subst-before](https://user-images.githubusercontent.com/48824213/179004552-4a990af3-daa1-4470-8364-a482d09d453d.png)
![my_backend_struct-before](https://user-images.githubusercontent.com/48824213/179004556-2b47722f-52a2-4221-8dff-b62591945c30.png)

### After

![export-subst-after](https://user-images.githubusercontent.com/48824213/179004596-8d7c66db-72e4-48eb-b6be-594f43dc65a8.png)
![my_backend_struct-after](https://user-images.githubusercontent.com/48824213/179004599-46de9f0d-2a06-4098-abe0-9c223dad6db2.png)

These were generated using `bundle exec rake book:build_pdf` with `Bundler version 2.3.17` and `ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-linux-gnu]`.

**However**, note that the first case with the `export-subst` section is rendered incorrectly on [the website](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes) as well, as expected:

![export-subst-website](https://user-images.githubusercontent.com/48824213/179005171-5c7cc591-ab11-420f-aafd-01f5b968f6d8.png)

whereas the second one is actually currently rendered correctly on the website:

![my_backend_struct-website](https://user-images.githubusercontent.com/48824213/179005430-6eb71259-63f8-40e5-b548-abd9947f325d.png)

No idea why, I couldn't find an issue mentioning that. Perhaps the HTML output is different from the PDF one. I reckon this change doesn't regress that so it's fine.

## Context

#1644
