### PR TITLE
Remove unnecessary dig at MS Word

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -37,7 +37,6 @@ You can also use the Git attributes functionality to effectively diff binary fil
 You do this by telling Git how to convert your binary data to a text format that can be compared via the normal diff.
 
 First, you'll use this technique to solve one of the most annoying problems known to humanity: version-controlling Microsoft Word documents.
-Everyone knows that Word is the most horrific editor around, but oddly, everyone still uses it.
 If you want to version-control Word documents, you can stick them in a Git repository and commit every once in a while; but what good does that do?
 If you run `git diff` normally, you only see something like this:
 


### PR DESCRIPTION
<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
I just removed one sentence that "comments" on MS Word. Either everybody agrees with the sentiment, making the sentence redundant, or not, making it alienating to some. Author's view is already apparent from the previous sentence. :smiley: 

btw: Thanks so much for a great resource! :clap:  
