### PR TITLE
add server-side hook: proc-receive

### DIFF
--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -116,7 +116,7 @@ You can use this hook to do things like make sure none of the updated references
 The `proc-receive` script is quite different from other server-side scripts, it is invoked by git push process, but can change the worklow or process between `pre-reveive` and
 `post-receive` script. This's because if the upcoming update references match the specified reference pattern, which can be configured by `receive.procReceiveRefs`, then `proc-receive`
 will take over the whole flow after `pre-receive`. It can decide to create, update or rename new reference, or even fallback to previous process.
-In other word, it can outsource reference processing flow, this give a system administrator to customize very useful policy for pushing workflow, such as Gerrit-like workflow in Git.
+In other words, it can outsource reference processing flow, this gives a system administrator to customize a very useful policy for pushing workflow, such as Gerrit-like workflow in Git.
 This script runs once at push process, and can stop the push process.
 
 ===== `update`

--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -113,9 +113,9 @@ You can use this hook to do things like make sure none of the updated references
 
 ===== `proc-receive`
 
-The `proc-receive` script is quite different from other server-side scripts, it is invoked by git push process, but can change the worklow or process between `pre-reveive` and
-`post-receive` script. This's because if the upcoming update references match the specified reference pattern, which can be configured by `receive.procReceiveRefs`, then `proc-receive`
-will take over the whole flow after `pre-receive`. It can decide to create, update or rename new reference, or even fallback to previous process.
+The `proc-receive` script is quite different from other server-side scripts, it is invoked by git push process, but can change the worklow or process between `pre-reveive` and `post-receive` script.
+This's because if the upcoming update references match the specified reference pattern, which can be configured by `receive.procReceiveRefs`, then `proc-receive` will take over the whole flow after `pre-receive`.
+It can decide to create, update or rename new reference, or even fallback to previous process.
 In other words, it can outsource reference processing flow, this gives a system administrator to customize a very useful policy for pushing workflow, such as Gerrit-like workflow in Git.
 This script runs once at push process, and can stop the push process.
 

--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -111,6 +111,14 @@ The first script to run when handling a push from a client is `pre-receive`.
 It takes a list of references that are being pushed from stdin; if it exits non-zero, none of them are accepted.
 You can use this hook to do things like make sure none of the updated references are non-fast-forwards, or to do access control for all the refs and files they're modifying with the push.
 
+===== `proc-receive`
+
+The `proc-receive` script is quite different from other server-side scripts, it is invoked by git push process, but can change the worklow or process between `pre-reveive` and
+`post-receive` script. This's because if the upcoming update references match the specified reference pattern, which can be configured by `receive.procReceiveRefs`, then `proc-receive`
+will take over the whole flow after `pre-receive`. It can decide to create, update or rename new reference, or even fallback to previous process.
+In other word, it can outsource reference processing flow, this give a system administrator to customize very useful policy for pushing workflow, such as Gerrit-like workflow in Git.
+This script runs once at push process, and can stop the push process.
+
 ===== `update`
 
 The `update` script is very similar to the `pre-receive` script, except that it's run once for each branch the pusher is trying to update.

--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -113,11 +113,13 @@ You can use this hook to do things like make sure none of the updated references
 
 ===== `proc-receive`
 
-The `proc-receive` script is quite different from other server-side scripts, it is invoked by git push process, but can change the worklow or process between `pre-reveive` and `post-receive` script.
-This's because if the upcoming update references match the specified reference pattern, which can be configured by `receive.procReceiveRefs`, then `proc-receive` will take over the whole flow after `pre-receive`.
-It can decide to create, update or rename new reference, or even fallback to previous process.
-In other words, it can outsource reference processing flow, this gives a system administrator to customize a very useful policy for pushing workflow, such as Gerrit-like workflow in Git.
-This script runs once at push process, and can stop the push process.
+The `proc-receive` script is quite different from other server-side scripts.
+It is invoked by git push process, but can change the worklow or process between `pre-receive` and `post-receive` script.
+If the incoming update references match the specified reference pattern (`receive.procReceiveRefs`), then `proc-receive` will take over the whole flow after `pre-receive`.
+It can decide to create, update or rename new reference, or even fall back to previous process.
+
+In other words, it can outsource reference processing flow.
+This gives a system administrator the ability to customize a pushing workflow, like that used in a Gerritt project.
 
 ===== `update`
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add new server side hook `proc-receive`

## Context
In git hooks, a new server side hook named `proc-receive` have been added in 2020. This is a very usefully hook, I think it shoud be known by more people, especialy the readers of this book.
