### PR TITLE
Mark up "input" as in-line code

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -402,7 +402,7 @@ $ git config --global core.autocrlf true
 ----
 
 If you're on a Linux or macOS system that uses LF line endings, then you don't want Git to automatically convert them when you check out files; however, if a file with CRLF endings accidentally gets introduced, then you may want Git to fix it.
-You can tell Git to convert CRLF to LF on commit but not the other way around by setting `core.autocrlf` to input:
+You can tell Git to convert CRLF to LF on commit but not the other way around by setting `core.autocrlf` to `input`:
 
 [source,console]
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Adds in-line code markup to the word "input",
  as it is mentioned as a setting value.

## Context

When mentioning the `core.autocrlf` value `true`, the text marks it up as in-line code.
This patch applies the same markup to the `input` value of the same setting.
