### PR TITLE
Fix clash with named anchor ID

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -84,7 +84,7 @@ You may find, if you don't setup your editor like this, you get into a really co
 An example on a Windows system may include a prematurely terminated Git operation during a Git initiated edit.
 ====
 
-[[_default_branch]]
+[[_new_default_branch]]
 ==== Your default branch name
 
 By default Git will create a branch called _master_ when you create a new repository with `git init`.

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -40,7 +40,7 @@ For now, that branch is always `master`, which is the default; you won't worry a
 ====
 GitHub changed the default branch name from `master` to `main` in mid-2020, and other Git hosts followed suit.
 So you may find that the default branch name in some newly created repositories is `main` and not `master`.
-In addition, the default branch name can be changed (as you have seen in <<ch01-getting-started#_default_branch>>), so you may see a different name for the default branch.
+In addition, the default branch name can be changed (as you have seen in <<ch01-getting-started#_new_default_branch>>), so you may see a different name for the default branch.
 
 However, Git itself still uses `master` as the default, so we will use it throughout the book.
 ====


### PR DESCRIPTION
Rename the anchor ID `[[_default_branch]]` to `[[_new_default_branch]]`, updating the reference
to it.

Fixes asciidoctor build warnings due to pre-existing [[_default_branch]] anchor ID of the same name.

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

-  Change the anchor ID name and/or reference in:

   ```
    book/01-introduction/sections/first-time-setup.asc 
    book/02-git-basics/sections/recording-changes.asc 
    ```
    This clashed with:
    ```
    book/06-github/sections/3-maintaining.asc
    ```

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->

commit 2af8f742c69c8cfac44ce56e1b51701948be93bc

added a reference `[[_default_branch]]`.

commit 1b64de1eb4023847fe371289ec2ca58ede6902be

adds a links to that reference.

However, the reference already existed in:

```
book/06-github/sections/3-maintaining.asc
```

created in 2014 with:

commit bf7ce71d803a33cf98a347527c9369221040a01c

Rename the new reference to `[[_new_default_branch]]` and update
the link to it.

Fixes asciidoctor build warnings (and possible future broken links).

```
asciidoctor: WARNING: book/06-github/sections/3-maintaining.asc: line 363: id assigned to block already in use: _default_branch
```

