### PR TITLE
Mention includes in configuration section

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -47,6 +47,11 @@ $ man git-config
 This command lists all the available options in quite a bit of detail.
 You can also find this reference material at https://git-scm.com/docs/git-config[^].
 
+[NOTE]
+====
+For advanced use cases you may want to look up "Conditional includes" in the documentation mentioned above.
+====
+
 ===== `core.editor`
 
 ((($EDITOR)))((($VISUAL, see $EDITOR)))


### PR DESCRIPTION
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add a note in 'Basic client configuration' mentioning Conditional includes 

## Context

When a user belongs to several organizations they may have different
identities or settings for the repos belonging to each
organization. Conditional include allow to apply those configuration
settings to each group without defining them on each repo
individually.

A big problem with the feature is its discoverability. A brief mention
in the configuration section to check out the details in the
documentation can dramatically raise awareness.

Fixes #1801