### PR TITLE
add nano on Windows via MSYS2 via git-for-windows

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -57,6 +57,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Gvim (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Vim\vim72\gvim.exe' --nofork '%*'"` (Also see note below)
 |Kate (Linux) |`git config --global core.editor "kate"`
 |nano |`git config --global core.editor "nano -w"`
+|nano MSYS2 git-for-windows (Windows 64-bit)|`git config --global core.editor "'C:\Program Files\Git\bin\bash.exe' -i -c \"nano \\\"$*\\\"\""` (Also see note below)
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
 |Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Notepad++\notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- add one line to the table in Appendix C which allows nano via MSYS2 bash.exe to be the editor on cmd and pwsh. I've only tested this via git-for-windows so I added that caveat. However both the name and the command line could be shorter if specific to "pure" MSYS2.

## Context
I spent an hour figuring out that this was really a string quoting/escaping problem and another half hour getting the escaping right. I figured maybe others could be spared the aggravation!