### PR TITLE
Let the reader knows that it will be cover

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -121,7 +121,7 @@ After you do this, you should have references to all the branches from that remo
 If you clone a repository, the command automatically adds that remote repository under the name "`origin`".
 So, `git fetch origin` fetches any new work that has been pushed to that server since you cloned (or last fetched from) it.
 It's important to note that the `git fetch` command only downloads the data to your local repository -- it doesn't automatically merge it with any of your work or modify what you're currently working on.
-You have to merge it manually into your work when you're ready.
+You have to merge it manually into your work when you're ready, but we will ignore manual merge for now.
 
 If your current branch is set up to track a remote branch (see the next section and <<ch03-git-branching#ch03-git-branching>> for more information), you can use the `git pull` command to automatically fetch and then merge that remote branch into your current branch.(((git commands, pull)))
 This may be an easier or more comfortable workflow for you; and by default, the `git clone` command automatically sets up your local `master` branch to track the remote `master` branch (or whatever the default branch is called) on the server you cloned from.


### PR DESCRIPTION
Just let the reader knows that manual merge is something that will be cover in the future and that the writer didn't abruptly change the subject to automatically fetch and merge.

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add few words to let reader knows that manual merge will be cover

## Context
The subject changed from `git fetch` and manual merge to automatically fetch and merge with `git pull`.  
