### PR TITLE
Added warning about the insecurity of git://

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -133,5 +133,5 @@ After this is done, you can also get Git via Git itself for updates:
 
 [source,console]
 ----
-$ git clone git://git.kernel.org/pub/scm/git/git.git
+$ git clone https://git.kernel.org/pub/scm/git/git.git
 ----

--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -191,7 +191,7 @@ This option adds a nice little ASCII graph showing your branch and merge history
 ----
 $ git log --pretty=format:"%h %s" --graph
 * 2d3acf9 Ignore errors from SIGCHLD on trap
-*  5e3ee11 Merge branch 'master' of git://github.com/dustin/grit
+*  5e3ee11 Merge branch 'master' of https://github.com/dustin/grit.git
 |\
 | * 420eac9 Add method for getting the current branch
 * | 30e367c Timeout code and tests

--- a/book/04-git-server/sections/gitweb.asc
+++ b/book/04-git-server/sections/gitweb.asc
@@ -36,7 +36,7 @@ First, you need to get the Git source code, which GitWeb comes with, and generat
 
 [source,console]
 ----
-$ git clone git://git.kernel.org/pub/scm/git/git.git
+$ git clone https://git.kernel.org/pub/scm/git/git.git
 $ cd git/
 $ make GITWEB_PROJECTROOT="/srv/git" prefix=/usr gitweb
     SUBDIR gitweb

--- a/book/04-git-server/sections/protocols.asc
+++ b/book/04-git-server/sections/protocols.asc
@@ -196,9 +196,12 @@ It uses the same data-transfer mechanism as the SSH protocol but without the enc
 
 ===== The Cons
 
-Due to the lack of TLS or other cryptography, cloning over git:// might lead to an arbitrary code execution vulnerability and should therefore be avoided unless you know what you are doing:
-If you run `git clone git://example.com/project.git` an attacker who controls e.g your router can modify the repo you just cloned, inserting malicious code into it. If you then compile/run the code you just cloned, you will execute the malicious code.
-Running `git clone http://example.com/project.git` should be avoided for the same reason. Running `git clone https://example.com/project.git` does not suffer from the same problem (unless the attacker can provide a TLS certificate for example.com). Running `git clone git@example.com:project.git` only suffers from this problem if you accept a wrong ssh key fingerprint.
+Due to the lack of TLS or other cryptography, cloning over `git://` might lead to an arbitrary code execution vulnerability, and should therefore be avoided unless you know what you are doing.
+
+* If you run `git clone git://example.com/project.git`, an attacker who controls e.g your router can modify the repo you just cloned, inserting malicious code into it. If you then compile/run the code you just cloned, you will execute the malicious code.
+  Running `git clone http://example.com/project.git` should be avoided for the same reason.
+*  Running `git clone https://example.com/project.git` does not suffer from the same problem (unless the attacker can provide a TLS certificate for example.com). 
+  Running `git clone git@example.com:project.git` only suffers from this problem if you accept a wrong ssh key fingerprint.
 
 It also has no authentication, i.e. anyone can clone the repo (although this is often exactly what you want).
 It's also probably the most difficult protocol to set up.

--- a/book/04-git-server/sections/protocols.asc
+++ b/book/04-git-server/sections/protocols.asc
@@ -181,7 +181,7 @@ If you want to allow anonymous read-only access to your projects and also want t
 
 (((protocols, git)))
 Finally, we have the Git protocol.
-This is a special daemon that comes packaged with Git; it listens on a dedicated port (9418) that provides a service similar to the SSH protocol, but with absolutely no authentication.
+This is a special daemon that comes packaged with Git; it listens on a dedicated port (9418) that provides a service similar to the SSH protocol, but with absolutely no authentication or cryptography.
 In order for a repository to be served over the Git protocol, you must create a `git-daemon-export-ok` file -- the daemon won't serve a repository without that file in it -- but, other than that, there is no security.
 Either the Git repository is available for everyone to clone, or it isn't.
 This means that there is generally no pushing over this protocol.
@@ -196,9 +196,11 @@ It uses the same data-transfer mechanism as the SSH protocol but without the enc
 
 ===== The Cons
 
-The downside of the Git protocol is the lack of authentication.
-It's generally undesirable for the Git protocol to be the only access to your project.
-Generally, you'll pair it with SSH or HTTPS access for the few developers who have push (write) access and have everyone else use `git://` for read-only access.
+Due to the lack of TLS or other cryptography, cloning over git:// might lead to an arbitrary code execution vulnerability and should therefore be avoided unless you know what you are doing:
+If you run `git clone git://example.com/project.git` an attacker who controls e.g your router can modify the repo you just cloned, inserting malicious code into it. If you then compile/run the code you just cloned, you will execute the malicious code.
+Running `git clone http://example.com/project.git` should be avoided for the same reason. Running `git clone https://example.com/project.git` does not suffer from the same problem (unless the attacker can provide a TLS certificate for example.com). Running `git clone git@example.com:project.git` only suffers from this problem if you accept a wrong ssh key fingerprint.
+
+It also has no authentication, i.e. anyone can clone the repo (although this is often exactly what you want).
 It's also probably the most difficult protocol to set up.
 It must run its own daemon, which requires `xinetd` or `systemd` configuration or the like, which isn't always a walk in the park.
 It also requires firewall access to port 9418, which isn't a standard port that corporate firewalls always allow.

--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -561,7 +561,7 @@ Jessica Smith (1):
 
 are available in the git repository at:
 
-  git://githost/simplegit.git featureA
+  https://githost/simplegit.git featureA
 
 Jessica Smith (2):
       Add limit to log function

--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -191,7 +191,7 @@ For instance, if Jessica sends you an email saying that she has a great new feat
 
 [source,console]
 ----
-$ git remote add jessica git://github.com/jessica/myproject.git
+$ git remote add jessica https://github.com/jessica/myproject.git
 $ git fetch jessica
 $ git checkout -b rubyclient jessica/ruby-client
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Cloning using git:// and running the cloned code is bad if e.g. you are in a public wifi.
Many people don't know that, (including me a few years ago), so I put that in the documentation.

