### PR TITLE
Correction recording-changes.asc

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -325,7 +325,7 @@ index 8ebb991..643e24f 100644
  that highlights your work in progress (and note in the PR title that it's
 ----
 
-That command compares what is in your working directory with what is in your staging area.
+That command compares what is in your working directory with what is in your Git repository.
 The result tells you the changes you've made that you haven't yet staged.
 
 If you want to see what you've staged that will go into your next commit, you can use `git diff --staged`.


### PR DESCRIPTION
<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [ ] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [ ] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

Modified the statement regarding the **'git diff'** command to clarify that it compares the changes between the files in your working directory and the files in your Git repository, and it shows the differences between the two sources. By default, it displays the changes that are not yet staged for commit. However, if you use the **'--staged'** or **'--cached'** option, **'git diff'** will compare the changes between the files in your staging area and the latest commit in your Git repository.