### PR TITLE
Sync apostrophe character

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -580,8 +580,8 @@ The history with the revert commit looks like this:
 .History after `git revert -m 1`
 image::images/undomerge-revert.png[History after `git revert -m 1`]
 
-The new commit `^M` has exactly the same contents as `C6`, so starting from here it's as if the merge never happened, except that the now-unmerged commits are still in `HEAD`’s history.
-Git will get confused if you try to merge `topic` into `master` again:
+The new commit `^M` has exactly the same contents as `C6`, so starting from here it's as if the merge never happened, except that the now-unmerged commits are still in ``HEAD```'s history.
+Git will get confused if you try to merge ``topic`` into ``master`` again:
 
 [source,console]
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- In previous commits the apostrophe characters were replaced with `'`. This syncs the remaining one. 
