### PR TITLE
Fix misspelled License page heading

### DIFF
--- a/book/license.asc
+++ b/book/license.asc
@@ -1,4 +1,4 @@
 [preface]
-== Licence
+== License
 
 include::../LICENSE.asc[]


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
Correct misspelled "Licence" heading on the License page.

Thanks for providing this great resource!