### PR TITLE
Update ssh env vars description

### DIFF
--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -209,8 +209,11 @@ nothing to commit, working directory clean
 
 *`GIT_SSH`*, if specified, is a program that is invoked instead of `ssh` when Git tries to connect to an SSH host.
 It is invoked like `$GIT_SSH [username@]host [-p <port>] <command>`.
-Note that this isn't the easiest way to customize how `ssh` is invoked; it won't support extra command-line parameters, so you'd have to write a wrapper script and set `GIT_SSH` to point to it.
-It's probably easier just to use the `~/.ssh/config` file for that.
+Note that this isn't the easiest way to customize how `ssh` is invoked; it won't support extra command-line parameters.
+To support extra command-line parameters, you can use *`GIT_SSH_COMMAND`*, write a wrapper script and set `GIT_SSH` to point to it or use the `~/.ssh/config` file.
+
+*`GIT_SSH_COMMAND`* sets the SSH command used when Git tries to connect to an SSH host.
+The command is interpreted by the shell, and extra command-line arguments can be used with `ssh`, such as `GIT_SSH_COMMAND="ssh -i ~/.ssh/my_key" git clone git@example.com:my/repo`.
 
 *`GIT_ASKPASS`* is an override for the `core.askpass` configuration value.
 This is the program invoked whenever Git needs to ask the user for credentials, which can expect a text prompt as a command-line argument, and should return the answer on `stdout` (see <<ch07-git-tools#_credential_caching>> for more on this subsystem).


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Adds a description of the `GIT_SSH_COMMAND` env variable.

## Context

Seems when this section was first written, `GIT_SSH_COMMAND` did not yet exist or wasn't as popular as it seems to be now. Especially when handling multiple keys across different git hosting services, it's a convenient way to quickly select the a given key for a given service.