### PR TITLE
Add new option --sparse to git add help output

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -43,6 +43,7 @@ usage: git add [<options>] [--] <pathspec>...
     --refresh                   don't add, only refresh the index
     --ignore-errors             just skip files which cannot be added because of errors
     --ignore-missing            check if - even missing - files are ignored in dry run
+    --sparse                    allow updating entries outside of the sparse-checkout cone
     --chmod (+|-)x              override the executable bit of the listed files
     --pathspec-from-file <file> read pathspec from file
     --pathspec-file-nul         with --pathspec-from-file, pathspec elements are separated with NUL character


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- There is a new option `--sparse` available for `git add` and the help output here is synced with the new one.