### PR TITLE
Fix placement of hidden index terms

### DIFF
--- a/book/09-git-and-other-scms/sections/import-bzr.asc
+++ b/book/09-git-and-other-scms/sections/import-bzr.asc
@@ -1,6 +1,6 @@
 ==== Bazaar
-(((Bazaar)))(((Importing, from Bazaar)))
 
+(((Bazaar)))(((Importing, from Bazaar)))
 Bazaar is a DVCS tool much like Git, and as a result it's pretty straightforward to convert a Bazaar repository into a Git one.
 To accomplish this, you'll need to import the `bzr-fastimport` plugin.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- According to [docs](https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/#index-terms) the index terms should be placed before the paragraph. Otherwise there are extra lines added in the PDF and other formats. 