### PR TITLE
Fix the next version calculation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
 namespace :book do
 
   # Variables referenced for build
-  version_string = `git describe --tags`.chomp
+  version_string = `git describe --tags --abbrev=0`.chomp
   if version_string.empty?
     version_string = '0'
+  else
+    versions = version_string.split('.')
+    version_string = versions[0] + '.' + versions[1] + '.' + versions[2].to_i.next.to_s
   end
   date_string = Time.now.strftime('%Y-%m-%d')
   params = "--attribute revnumber='#{version_string}' --attribute revdate='#{date_string}'"


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Version written in the book was one tag behind the one on the PDF at GitHub releases. Next tag needed to be calculated here.

Steps to reproduce the issue:

- Visit https://git-scm.com/book/en/v2
- Download PDF
- Version in the PDF and the last published tag on the GitHub releases don't match (one patch behind)
