### PR TITLE
Fix link to Perforce tools

### DIFF
--- a/book/09-git-and-other-scms/sections/client-p4.asc
+++ b/book/09-git-and-other-scms/sections/client-p4.asc
@@ -15,12 +15,12 @@ The second is git-p4, a client-side bridge that lets you use Git as a Perforce c
 ===== Git Fusion
 
 (((Perforce, Git Fusion)))
-Perforce provides a product called Git Fusion (available at https://www.perforce.com/git-fusion[^]), which synchronizes a Perforce server with Git repositories on the server side.
+Perforce provides a product called Git Fusion (available at https://www.perforce.com/manuals/git-fusion/[^]), which synchronizes a Perforce server with Git repositories on the server side.
 
 ====== Setting Up
 
 For our examples, we'll be using the easiest installation method for Git Fusion, which is downloading a virtual machine that runs the Perforce daemon and Git Fusion.
-You can get the virtual machine image from https://www.perforce.com/downloads/Perforce/20-User[^], and once it's finished downloading, import it into your favorite virtualization software (we'll use VirtualBox).
+You can get the virtual machine image from https://www.perforce.com/downloads[^], and once it's finished downloading, import it into your favorite virtualization software (we'll use VirtualBox).
 
 Upon first starting the machine, it asks you to customize the password for three Linux users (`root`, `perforce`, and `git`), and provide an instance name, which can be used to distinguish this installation from others on the same network.
 When that has all completed, you'll see this:
@@ -323,7 +323,7 @@ Git-p4 isn't as flexible or complete a solution as Git Fusion, but it does allow
 [NOTE]
 ======
 You'll need the `p4` tool somewhere in your `PATH` to work with git-p4.
-As of this writing, it is freely available at http://www.perforce.com/downloads/Perforce/20-User[^].
+As of this writing, it is freely available at https://www.perforce.com/downloads/helix-command-line-client-p4[^].
 ======
 
 ====== Setting Up


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Link to Git Fusion has been redirected. I've replaced the link with the Git Fusion manual instead.
- Link to virtual machine has been also redirected in the mean time and now points to downloads instead.
- Download link to p4 tool has been replaced with the Helix command line client p4 link.

