### PR TITLE
Fix #1893: git commit should be able to wait for Kate editor

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -56,7 +56,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Gedit (Linux) |`git config --global core.editor "gedit --wait --new-window"`
 |Gvim (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Vim\vim72\gvim.exe' --nofork '%*'"` (Also see note below)
 |Helix |`git config --global core.editor "helix"`
-|Kate (Linux) |`git config --global core.editor "kate"`
+|Kate (Linux) |`git config --global core.editor "kate --block"`
 |nano |`git config --global core.editor "nano -w"`
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
 |Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Notepad++\notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)


### PR DESCRIPTION
Kate editor must be started with "--block" option so git commit can patiently wait for the editor to close the commit message file.

- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).


## Context
Fixes #1893