### PR TITLE
Add how to use remote-submodules

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -185,7 +185,7 @@ Submodule path 'DbConnector': checked out 'c3f01dc8862123d317dd46284b05b6892c7b2
 Now your `DbConnector` subdirectory is at the exact state it was in when you committed earlier.
 
 There is another way to do this which is a little simpler, however.
-If you pass `--recurse-submodules` to the `git clone` command, it will automatically initialize and update each submodule in the repository, including nested submodules if any of the submodules in the repository have submodules themselves.
+If you pass `--recurse-submodules` to the `git clone` command, it will automatically initialize and update each submodule in the repository, including nested submodules if any of the submodules in the repository have submodules themselves. If you also want to update the submodules to their latest revision then add `--remote-submodules`.
 
 [source,console]
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Current [doc](https://git-scm.com/book/en/v2/Git-Tools-Submodules) confuse me.
"There is another way to do this which is a little simpler, however. If you pass --recurse-submodules to the git clone command, it will automatically initialize **and update** each submodule in the repository, including nested submodules if any of the submodules in the repository have submodules themselves."
I add how to use --remote-submodules option. For example I clone repo with recursive flag
`git clone --recurse-submodules https://github.com/apc-llc/moviemaker-cpp.git`
but googletest submodule still has old version because --recurse-submodules option in fact don't do **and update** as doc promise. I also need --remote-submodules option.
`git clone --recurse-submodules --remote-submodules  https://github.com/apc-llc/moviemaker-cpp.git`
Now googletest submodule has last version.

## Context
git with submodule
Thanks https://stackoverflow.com/a/3797061/7915017
