### PR TITLE
Suggest ed25519 ssh keys in generate-ssh-key section

### DIFF
--- a/book/04-git-server/sections/generating-ssh-key.asc
+++ b/book/04-git-server/sections/generating-ssh-key.asc
@@ -13,29 +13,28 @@ You can easily check to see if you have a key already by going to that directory
 ----
 $ cd ~/.ssh
 $ ls
-authorized_keys2  id_dsa       known_hosts
-config            id_dsa.pub
+authorized_keys  id_ed25519      known_hosts
+config           id_ed25519.pub
 ----
 
-You're looking for a pair of files named something like `id_dsa` or `id_rsa` and a matching file with a `.pub` extension.
+You're looking for a pair of files named something like `id_ed25519` or `id_rsa` and a matching file with a `.pub` extension.
 The `.pub` file is your public key, and the other file is the corresponding private key.
 If you don't have these files (or you don't even have a `.ssh` directory), you can create them by running a program called `ssh-keygen`, which is provided with the SSH package on Linux/macOS systems and comes with Git for Windows:
 
 [source,console]
 ----
-$ ssh-keygen -o
-Generating public/private rsa key pair.
-Enter file in which to save the key (/home/schacon/.ssh/id_rsa):
-Created directory '/home/schacon/.ssh'.
-Enter passphrase (empty for no passphrase):
-Enter same passphrase again:
-Your identification has been saved in /home/schacon/.ssh/id_rsa.
-Your public key has been saved in /home/schacon/.ssh/id_rsa.pub.
+$ ssh-keygen -t ed25519
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/home/schacon/.ssh/id_ed25519):
+Enter passphrase (empty for no passphrase): 
+Enter same passphrase again: 
+Your identification has been saved in 
+Your public key has been saved in .pub
 The key fingerprint is:
-d0:82:24:8e:d7:f1:bb:9b:33:53:96:93:49:da:9b:e3 schacon@mylaptop.local
+SHA256:YbzXDzVobzB9j4iV7PoVe1RSK3pLCYgNnoux4DGZ934 schacon@mylaptop.local
 ----
 
-First it confirms where you want to save the key (`.ssh/id_rsa`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
+First it confirms where you want to save the key (`.ssh/id_ed25519`), and then it asks twice for a passphrase, which you can leave empty if you don't want to type a password when you use the key.
 However, if you do use a password, make sure to add the `-o` option; it saves the private key in a format that is more resistant to brute-force password cracking than is the default format.
 You can also use the `ssh-agent` tool to prevent having to enter the password each time.
 
@@ -45,13 +44,8 @@ The public keys look something like this:
 
 [source,console]
 ----
-$ cat ~/.ssh/id_rsa.pub
-ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU
-GPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3
-Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA
-t3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En
-mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx
-NrRFi9wrf+M7Q== schacon@mylaptop.local
+$ cat ~/.ssh/id_ed25519.pub 
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFiASV2XEvhnSzMoRevGsq9rjsHVtCl05WV4cBPPVKOP schacon@mylaptop.local
 ----
 
 For a more in-depth tutorial on creating an SSH key on multiple operating systems, see the GitHub guide on SSH keys at https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent[^].


### PR DESCRIPTION


- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [ ] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- DSA is not considered secure any longer.
- Ed25519 produces smaller public keys than RSA.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
