### PR TITLE
Remove syslog constructs from git-daemon unit file

### DIFF
--- a/book/04-git-server/sections/git-daemon.asc
+++ b/book/04-git-server/sections/git-daemon.asc
@@ -35,10 +35,6 @@ ExecStart=/usr/bin/git daemon --reuseaddr --base-path=/srv/git/ /srv/git/
 Restart=always
 RestartSec=500ms
 
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=git-daemon
-
 User=git
 Group=git
 


### PR DESCRIPTION
## Changes

- Remove `StandardOutput`, `StandardError`, and `SyslogIdentifier` from the `git-daemon` `systemd` unit file example.

## Context

The `syslog` output type for  `StandardOutput` and `StandardError` in the `git-daemon` unit file is obsolete, along with the `SyslogIdentifier` option. Since `StandardOutput=journal` and `StandardError=inherit` are now the defaults we can leave them unspecified. Journal entries can be filtered with `journalctl -u git-daemon` so we don't need the `SyslogIdentifier`.

## Licensing

- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).