### PR TITLE
ch10-maintenance: make pack .idx look like a SHA-1 hash

### DIFF
--- a/book/10-git-internals/sections/maintenance.asc
+++ b/book/10-git-internals/sections/maintenance.asc
@@ -253,7 +253,7 @@ You can also pipe it through the `tail` command because you're only interested i
 
 [source,console]
 ----
-$ git verify-pack -v .git/objects/pack/pack-29…69.idx \
+$ git verify-pack -v .git/objects/pack/pack-e7f…069.idx \
   | sort -k 3 -n \
   | tail -3
 dadf7258d699da2c8d89b09ef6670edb7d5f91b4 commit 229 159 12


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

```diff
-$ git verify-pack -v .git/objects/pack/pack-29…69.idx \
+$ git verify-pack -v .git/objects/pack/pack-e7f…069.idx \
```

## Context

At first I stumbled upon the ellipsis ... here because it seemed like a git/Shell macro to expand paths for packs numbered 29-69. But it's not a short-hand for anything, what was meant here is simply the full SHA-1 hash as part of the file name. So I changed it to look like an actual hex number.

Sufficient attention was paid to keep the second number as it appeared in the book ;)
