### PR TITLE
Replace deprected command: which

### DIFF
--- a/book/04-git-server/sections/setting-up-server.asc
+++ b/book/04-git-server/sections/setting-up-server.asc
@@ -96,7 +96,7 @@ To do so, you must first add the full pathname of the `git-shell` command to `/e
 [source,console]
 ----
 $ cat /etc/shells   # see if git-shell is already in there. If not...
-$ which git-shell   # make sure git-shell is installed on your system.
+$ command -v git-shell   # make sure git-shell is installed on your system.
 $ sudo -e /etc/shells  # and add the path to git-shell from last command
 ----
 
@@ -104,7 +104,7 @@ Now you can edit the shell for a user using `chsh <username> -s <shell>`:
 
 [source,console]
 ----
-$ sudo chsh git -s $(which git-shell)
+$ sudo chsh git -s "$(command -v git-shell)"
 ----
 
 Now, the `git` user can still use the SSH connection to push and pull Git repositories but can't shell onto the machine.


### PR DESCRIPTION

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

"which" was deprecated in favour of "command -v" in Debian.

## Context

Further reading: https://lwn.net/Articles/874049/