### PR TITLE
Use new shell command substitution syntax

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -512,7 +512,7 @@ The command to do this is `git archive`:
 
 [source,console]
 ----
-$ git archive master --prefix='project/' | gzip > `git describe master`.tar.gz
+$ git archive master --prefix='project/' | gzip > "$(git describe master).tar.gz"
 $ ls *.tar.gz
 v1.6.2-rc1-20-g8c5b85c.tar.gz
 ----
@@ -522,7 +522,7 @@ You can also create a zip archive in much the same way, but by passing the `--fo
 
 [source,console]
 ----
-$ git archive master --prefix='project/' --format=zip > `git describe master`.zip
+$ git archive master --prefix='project/' --format=zip > "$(git describe master).zip"
 ----
 
 You now have a nice tarball and a zip archive of your project release that you can upload to your website or email to people.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

book/05-distributed-git/sections/maintaining.asc

```diff
-$ git archive master --prefix='project/' | gzip > `git describe master`.tar.gz
+$ git archive master --prefix='project/' | gzip > "$(git describe master).tar.gz"
```

## Context
The old `command` syntax is considered obsolete.
We can take this opportunity to teach proper syntax going forward, also putting command output in double-quotes eliminating unintended separation into multiple arguments for space characters.

Rationale: https://unix.stackexchange.com/a/126928

No other occurrences were found:

```
rg --engine pcre2 '^\$.*`.+`'
```