### PR TITLE
fixed typo in chapter 8 under core.pager

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -129,7 +129,7 @@ You can set it to `more` or to your favorite pager (by default, it's `less`), or
 $ git config --global core.pager ''
 ----
 
-If you run that, Git will page the entire output of all commands, no matter how long they are.
+If you run that, Git will print the entire output of all commands, no matter how long they are.
 
 ===== `user.signingkey`
 


### PR DESCRIPTION
There is a typo in chapter 8 under core.pager last line, it say 'Git will page'. The word 'page' should be replaced with the word 'print'

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fixed typo in last line of chapter 8 under core.pager.
- The word "page" is replaced by "print".

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
Fixes #1925 