### PR TITLE
specify which Update>> prompt is referred to in interactive-staging

### DIFF
--- a/book/07-git-tools/sections/interactive-staging.asc
+++ b/book/07-git-tools/sections/interactive-staging.asc
@@ -53,7 +53,7 @@ Update>>
 ----
 
 The `*` next to each file means the file is selected to be staged.
-If you press Enter after typing nothing at the `Update>>` prompt, Git takes anything selected and stages it for you:
+If you press Enter after typing nothing at the second `Update>>` prompt, Git takes anything selected and stages it for you:
 
 [source,console]
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).



## Context
A somewhat inattentive reader (me, when I read the chapter) may be temporarily confused about which of the `Update>>`prompts the (in this PR edited) sentence is referring to as the previous prompt was also an `Update>>` prompt.
I believe this change would make the chapter slightly more easily understandable, but if you disagree and think I am the only person this would ever happen to (which is possible, the PR is merely based on my personal reading experience) or that this is not worth changing, then you can safely ignore and close the PR.

The following is the excerpt this change is about:
```asc
To stage the `TODO` and `index.html` files, you can type the numbers:

[source,console]
----
Update>> 1,2
           staged     unstaged path
* 1:    unchanged        +0/-1 TODO
* 2:    unchanged        +1/-1 index.html
  3:    unchanged        +5/-1 lib/simplegit.rb
Update>>
----

The `*` next to each file means the file is selected to be staged.
If you press Enter after typing nothing at the `Update>>` prompt, Git takes anything selected and stages it for you:
```
