### PR TITLE
Replace 'in lieu of' with 'instead of'

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -87,7 +87,7 @@ pb	https://github.com/paulboone/ticgit (fetch)
 pb	https://github.com/paulboone/ticgit (push)
 ----
 
-Now you can use the string `pb` on the command line in lieu of the whole URL.
+Now you can use the string `pb` on the command line instead of the whole URL.
 For example, if you want to fetch all the information that Paul has but that you don't yet have in your repository, you can run `git fetch pb`:
 
 [source,console]


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Replace _in lieu of_ with _instead of_.

## Context

While reading the book, I bumped into this "in lieu of" expression, and as a non-native English speaker, I had to google it to understand it.

I think these are the reasons to make this change:
- **consistency**: [this is **the only** place in the book where this expression is used](https://github.com/search?q=repo%3Aprogit%2Fprogit2+%22in+lieu+of%22&type=code), while "instead of" is [used many times](https://github.com/search?q=repo%3Aprogit%2Fprogit2+%22instead+of%22&type=code) (36 at this moment).
- **understandability**: I believe there are (and will be) many non-native English people reading this book, and using a more common expression will make it easier for them to understand the content.