### PR TITLE
Escape notepad++ default installation path

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -59,7 +59,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Kate (Linux) |`git config --global core.editor "kate --block"`
 |nano |`git config --global core.editor "nano -w"`
 |Notepad (Windows 64-bit) |`git config core.editor notepad`
-|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Notepad++\notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)
+|Notepad++ (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Notepad+\+\notepad++.exe' -multiInst -notabbar -nosession -noPlugin"` (Also see note below)
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
 |Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
 |Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Sublime Text 3\sublime_text.exe' -w"` (Also see note below)


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add a single backslash to the Notepad++ editor path in A3.1 Setup and Config.

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
It appears that the pair of "++" in the Notepad++ path may be interpreted as an inline passthrough by Asciidoctor. The double pluses are omitted in the rendered text (both on git-scm.com and the .pdf in the latest release.) The resulting command is incorrect if copied and pasted into the terminal, which is exactly what I had done when I noticed the problem.

If GitHub's web editor is rendering my change correctly, a single backslash in the first pair of double pluses is enough to fix the issue. After reading the contributing guidelines, I figured this is a minor enough correction that I did not need to open an issue first, but I have not contributed before. Constructive criticism welcomed. Thank you for your time.