### PR TITLE
Fixes issue1969

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -177,7 +177,7 @@ include::../git-credential-read-only[]
 <4> This loop reads the contents of the storage file, looking for matches.
     If the protocol, host, and username from `known` match this line, the program prints the results to stdout and exits.
 
-We'll save our helper as `git-credential-read-only`, put it somewhere in our `PATH` and mark it executable.
+We'll save our helper as `git-credential-read-only`, put it somewhere in our `GIT_EXEC_PATH` (see <<ch10-git-internals#_global_bahavior>> for more information) and mark it executable.
 Here's what an interactive session looks like:
 
 [source,console]

--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -4,6 +4,7 @@ Git always runs inside a `bash` shell, and uses a number of shell environment va
 Occasionally, it comes in handy to know what these are, and how they can be used to make Git behave the way you want it to.
 This isn't an exhaustive list of all the environment variables Git pays attention to, but we'll cover the most useful.
 
+[[_global_bahavior]]
 ==== Global Behavior
 
 Some of Git's general behavior as a computer program depends on environment variables.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Corrects the `PATH` environment variable for storing git-credential-read-only in [07-git-tools/sections/credentials.asc](https://github.com/progit/progit2/blob/main/book/07-git-tools/sections/credentials.asc) to `GIT_EXEC_PATH`.
- Create a reference ID to [10-git-internals/sections/environment.asc#global-behavior](https://github.com/progit/progit2/blob/main/book/10-git-internals/sections/environment.asc#global-behavior).

## Context

Fixes #1969 
