### PR TITLE
Modify ruby scripts: File.exists? to File.exist?

### DIFF
--- a/book/07-git-tools/git-credential-read-only
+++ b/book/07-git-tools/git-credential-read-only
@@ -11,7 +11,7 @@ OptionParser.new do |opts|
 end.parse!
 
 exit(0) unless ARGV[0].downcase == 'get' # <2>
-exit(0) unless File.exists? path
+exit(0) unless File.exist? path
 
 known = {} # <3>
 while line = STDIN.gets


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Modify ruby scripts `git-credential-read-only`: `File.exists?` to `File.exist?`
