### PR TITLE
Remove recommendation for git fetch && git merge over git pull

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -217,8 +217,6 @@ It will simply get the data for you and let you merge it yourself.
 However, there is a command called `git pull` which is essentially a `git fetch` immediately followed by a `git merge` in most cases.
 If you have a tracking branch set up as demonstrated in the last section, either by explicitly setting it or by having it created for you by the `clone` or `checkout` commands, `git pull` will look up what server and branch your current branch is tracking, fetch from that server and then try to merge in that remote branch.
 
-Generally it's better to simply use the `fetch` and `merge` commands explicitly as the magic of `git pull` can often be confusing.
-
 [[_delete_branches]]
 ==== Deleting Remote Branches
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
Remove the recommendation for `git fetch && git merge` over `git pull`

## Context
Fixes #2020 
