### PR TITLE
Clarify that --global configuration is not applicable system-wide

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -42,7 +42,7 @@ $ git config --global user.name "John Doe"
 $ git config --global user.email johndoe@example.com
 ----
 
-Again, you need to do this only once if you pass the `--global` option, because then Git will always use that information for anything you do while logged in as you on that system.
+Again, you need to do this only once if you pass the `--global` option, because then Git will always use that information for your user on that system.
 If you want to override this with a different name or email address for specific projects, you can run the command without the `--global` option when you're in that project.
 
 Many of the GUI tools will help you do this when you first run them.

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -42,7 +42,7 @@ $ git config --global user.name "John Doe"
 $ git config --global user.email johndoe@example.com
 ----
 
-Again, you need to do this only once if you pass the `--global` option, because then Git will always use that information for anything you do on that system.
+Again, you need to do this only once if you pass the `--global` option, because then Git will always use that information for anything you do while logged in as you on that system.
 If you want to override this with a different name or email address for specific projects, you can run the command without the `--global` option when you're in that project.
 
 Many of the GUI tools will help you do this when you first run them.


### PR DESCRIPTION
Clarify that --global configuration is not applicable system-wide, but only within the scope of the logged in as current user.

- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
add "while logged in as you"

## Context
Configuration via the  `--global` option does not affect everything "on that system". I believe it is limited in scope to the user. This change attempt to make that clear. It could be worded better but I'm struggling to come with anything better than this!