### PR TITLE
Fix grammar on how git svn fetches tags

### DIFF
--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -158,7 +158,7 @@ c3dcbe8488c6240392e8a5d7553bbffcb0f94ef0 refs/remotes/origin/master
 6dcb09b5b57875f334f61aebed695e2e4193db5e refs/tags/v1.0.0
 ----
 
-Git fetches the tags directly into `refs/tags`, rather than treating them remote branches.
+Git fetches the tags directly into `refs/tags`, rather than treating them as remote branches.
 
 ===== Committing Back to Subversion
 


### PR DESCRIPTION
The wording "rather than treating them remote branches." is missing a preposition "as".

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fixes a grammatical error in client-svm.asc: "rather than treating them remote branches"

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
