### PR TITLE
Migrate Dependabot reviewers to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
 # Users listed in the CODEOWNERS file must review (and approve) PRs before merge.
 
 @ben
+
+# GitHub recommends listing the code owner in the CODEOWNER file.
+# This means changes to the CODEOWNERS file must be reviewed by the code owner.
+
+/.github/CODEOWNERS @ben

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Users listed in the CODEOWNERS file must review (and approve) PRs before merge.
 
-@ben
+# Global code owners.
+* @ben
 
 # GitHub recommends listing the code owner in the CODEOWNER file.
 # This means changes to the CODEOWNERS file must be reviewed by the code owner.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Users listed in the CODEOWNERS file must review (and approve) PRs before merge.
+
+@ben

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     schedule:
       interval: "daily" # Checks on Monday through Friday.
 
-    # Set default reviewer and labels
-    reviewers:
-      - "ben"
+    # Set default labels
     labels:
       - "dependabot"


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Migrate from Dependabot's `reviewers` field to a `CODEOWNERS` file

## Context

GitHub is going to stop listening to the `reviewers` soon (Tuesday 27 may). GitHub recommends using a `CODEOWNERS` file to control who must review incoming PRs.

The `CODEOWNERS` config pings `@ben` for all incoming PRs, and requires their approval before merge.

GitHub recommends explictly listing the code owner for the CODEOWNERS file. I'm following that recommendation in this PR.

I think you (`@ben`) will need to set up branch protection rules to make sure the CODEOWNERS need to review the changes before merge? Quote from the GitHub Docs:

> Repository owners can update branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Edit your branch protection rule and enable the option "Require review from Code Owners". For more information, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).

### References

- [GitHub Blog, Dependabot reviewers configuration option being replaced by code owners](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)
- [GitHub Docs, about code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
