### PR TITLE
fixed typo in section 1.6

### DIFF
--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -125,7 +125,7 @@ John Doe
 
 [NOTE]
 ====
-Since Git might read the same configuration variable value from more than one file, it's possible that you have an unexpected value for one of these values and you don't know why.
+Since Git might read the same configuration variable value from more than one file, it's possible that you have an unexpected value for one of these variables and you don't know why.
 In cases like that, you can query Git as to the _origin_ for that value, and it will tell you which configuration file had the final say in setting that value:
 
 [source,console]


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Fixed typo in section 1.6: “values” should be replaced with “variables”.

## Context

Consider the beginning of this sentence: “Since Git might read the same configuration variable value from more than one file, … ” — having read this part of the sentence, one concludes that a “value” belongs to a “variable”. But the remaining part of the sentence implies that a “value” belongs to a value (“one of these values”) (“ … it's possible that you have an unexpected value for one of these values and you don't know why.”)

<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
