### PR TITLE
docs(installing.asc): fix package names for RPM-based distributions

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -67,14 +67,16 @@ Some people may instead find it useful to install Git from source, because you'l
 The binary installers tend to be a bit behind, though as Git has matured in recent years, this has made less of a difference.
 
 If you do want to install Git from source, you need to have the following libraries that Git depends on: autotools, curl, zlib, openssl, expat, and libiconv.
-For example, if you're on a system that has `dnf` (such as Fedora) or `apt-get` (such as a Debian-based system), you can use one of these commands to install the minimal dependencies for compiling and installing the Git binaries:
+For example, if you're on a system that has `dnf` (such as Fedora), `apt-get` (such as a Debian), or `zypper` (such as SUSE), you can use one of these commands to install the minimal dependencies for compiling and installing the Git binaries:
 
 [source,console]
 ----
-$ sudo dnf install dh-autoreconf curl-devel expat-devel gettext-devel \
+$ sudo dnf install autoconf curl-devel expat-devel gettext-devel \
   openssl-devel perl-devel zlib-devel
 $ sudo apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev \
   gettext libz-dev libssl-dev
+$ sudo zypper install autoconf curl-devel libexpat-devel gettext-devel \
+  openssl-devel zlib-devel patterns-devel-perl-devel_perl
 ----
 
 In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required:
@@ -83,11 +85,12 @@ In order to be able to add the documentation in various formats (doc, html, info
 ----
 $ sudo dnf install asciidoc xmlto docbook2X
 $ sudo apt-get install asciidoc xmlto docbook2x
+$ sudo zypper install asciidoc xmlto docbook2x
 ----
 
 [NOTE]
 ====
-Users of RHEL and RHEL-derivatives like CentOS and Scientific Linux will have to https://docs.fedoraproject.org/en-US/epel/#how_can_i_use_these_extra_packages[enable the EPEL repository^] to download the `docbook2X` package.
+Users of RHEL and RHEL-derivatives like CentOS or AlmaLinux will have to https://docs.fedoraproject.org/en-US/epel/#how_can_i_use_these_extra_packages[enable the EPEL repository^] to download the `docbook2X` package.
 ====
 
 If you're using a Debian-based distribution (Debian/Ubuntu/Ubuntu-derivatives), you also need the `install-info` package:
@@ -97,21 +100,30 @@ If you're using a Debian-based distribution (Debian/Ubuntu/Ubuntu-derivatives), 
 $ sudo apt-get install install-info
 ----
 
-If you're using a RPM-based distribution (Fedora/RHEL/RHEL-derivatives), you also need the `getopt` package (which is already installed on a Debian-based distro):
+If you're using a distribution from the Fedora/RHEL family or SUSE family, you also need the `gengetopt` package:
 
 [source,console]
 ----
-$ sudo dnf install getopt
+$ sudo dnf install gengetopt
+$ sudo zypper install gengetopt
 ----
 
-Additionally, if you're using Fedora/RHEL/RHEL-derivatives, you need to do this:
+If you're using a distribution from the SUSE family, you also need the `makeinfo` package:
 
 [source,console]
 ----
+$ sudo zypper install makeinfo
+----
+
+Additionally, if you're using a non Debian-based distribution, due to binary name differences, you need to create a symbolic link for `dockbook2x-texi`:
+
+[source,console]
+----
+$ # for a distribution from the Fedora/RHEL family:
 $ sudo ln -s /usr/bin/db2x_docbook2texi /usr/bin/docbook2x-texi
+$ # for a distribution from the SUSE family:
+$ sudo ln -s /usr/bin/docbook-to-texi /usr/bin/docbook2x-texi
 ----
-
-due to binary name differences.
 
 When you have all the necessary dependencies, you can go ahead and grab the latest tagged release tarball from several places.
 You can get it via the kernel.org site, at https://www.kernel.org/pub/software/scm/git[^], or the mirror on the GitHub website, at https://github.com/git/git/tags[^].
@@ -121,10 +133,10 @@ Then, compile and install:
 
 [source,console]
 ----
-$ tar -zxf git-2.8.0.tar.gz
-$ cd git-2.8.0
+$ tar -zxf git-2.49.0.tar.gz
+$ cd git-2.49.0
 $ make configure
-$ ./configure --prefix=/usr
+$ ./configure --prefix=/usr/local
 $ make all doc info
 $ sudo make install install-doc install-html install-info
 ----


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Fix compilation instructions (mostly package names) for RPM-based distributions (Fedora, RHEL, SUSE…).

## Context

The current compilation instructions currently reference packages that don't exist on Fedora/RHEL/SUSE.