### PR TITLE
Enhance the push cmd to also track the newly pushed branch

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -582,7 +582,7 @@ For example, if you want to submit a second topic of work to the project, don't 
 $ git checkout -b featureB origin/master
   ... work ...
 $ git commit
-$ git push myfork featureB
+$ git push -u myfork featureB
 $ git request-pull origin/master myfork
   ... email generated request pull to maintainer ...
 $ git fetch origin
@@ -623,7 +623,7 @@ $ git checkout -b featureBv2 origin/master
 $ git merge --squash featureB
   ... change implementation ...
 $ git commit
-$ git push myfork featureBv2
+$ git push -u myfork featureBv2
 ----
 
 The `--squash` option takes all the work on the merged branch and squashes it into one changeset producing the repository state as if a real merge happened, without actually making a merge commit.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes
The git push examples for new branches have been updated to include the -u flag, which sets the upstream tracking branch.

## Context
This change adds the -u flag to the initial git push for these new branches. Because these branches are newly created locally, they don't yet track a remote branch. This update makes the examples consistent with others in the section and reflects a modern best practice that simplifies all future push and pull commands.