### PR TITLE
[Fix] missing + in pdf, 10-git-internals/refspec

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -18,7 +18,7 @@ Running the command above adds a section to your repository's `.git/config` file
 	fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-The format of the refspec is, first, an optional `+`, followed by `<src>:<dst>`, where `<src>` is the pattern for references on the remote side and `<dst>` is where those references will be tracked locally.
+The format of the refspec is, first, an optional `{plus}`, followed by `<src>:<dst>`, where `<src>` is the pattern for references on the remote side and `<dst>` is where those references will be tracked locally.
 The `+` tells Git to update the reference even if it isn't a fast-forward.
 
 In the default case that is automatically written by a `git remote add origin` command, Git fetches all the references under `refs/heads/` on the server and writes them to `refs/remotes/origin/` locally.


### PR DESCRIPTION


<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- changed `+` to `{plus}` in 10-git-internals/refspec.asc 
  - "an optional `+` work" fine in html but not in pdf, resulted in changed to `{plus}` to make sure it renders plus sign in pdf

## Context

This is quite self-obvious so I did not open the Issue
