### PR TITLE
Fix broken JGit links

### DIFF
--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -3,7 +3,7 @@
 (((jgit)))(((Java)))
 If you want to use Git from within a Java program, there is a fully featured Git library called JGit.
 JGit is a relatively full-featured implementation of Git written natively in Java, and is widely used in the Java community.
-The JGit project is under the Eclipse umbrella, and its home can be found at https://www.eclipse.org/jgit/[^].
+The JGit project is under the Eclipse umbrella, and its home can be found at https://projects.eclipse.org/projects/technology.jgit[^].
 
 ==== Getting Set Up
 
@@ -22,7 +22,7 @@ Probably the easiest is to use Maven – the integration is accomplished by addi
 The `version` will most likely have advanced by the time you read this; check https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit[^] for updated repository information.
 Once this step is done, Maven will automatically acquire and use the JGit libraries that you'll need.
 
-If you would rather manage the binary dependencies yourself, pre-built JGit binaries are available from https://www.eclipse.org/jgit/download[^].
+If you would rather manage the binary dependencies yourself, pre-built JGit binaries are available from https://projects.eclipse.org/projects/technology.jgit/downloads[^].
 You can build them into your project by running a command like this:
 
 [source,console]
@@ -155,6 +155,6 @@ Many other commands are available through the Git class, including but not limit
 This is only a small sampling of JGit's full capabilities.
 If you're interested and want to learn more, here's where to look for information and inspiration:
 
-* The official JGit API documentation can be found at https://www.eclipse.org/jgit/documentation[^].
+* The official JGit API documentation can be found at https://help.eclipse.org/latest/topic/org.eclipse.egit.doc/help/JGit/User_Guide/User-Guide.html[^].
   These are standard Javadoc, so your favorite JVM IDE will be able to install them locally, as well.
 * The JGit Cookbook at https://github.com/centic9/jgit-cookbook[^] has many examples of how to do specific tasks with JGit.


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- The current JGit links are broken. Let's update them to non-broken ones.

## Context

This fixes https://github.com/git/git-scm.com/issues/2044.