### PR TITLE
Minor typo in note on git push and types of tags sent to server

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -218,7 +218,7 @@ To git@github.com:schacon/simplegit.git
 Now, when someone else clones or pulls from your repository, they will get all your tags as well.
 
 [NOTE]
-.`git push` pushes both types of tags
+.`git push origin <tagname>` pushes both types of tags
 ====
 `git push <remote> --tags` will push both lightweight and annotated tags.
 There is currently no option to push only lightweight tags, but if you use `git push <remote> --follow-tags` only annotated tags will be pushed to the remote.


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Minor typo in note on git push and types of tags that it sends to the server

## Context
Earlier in this chapter it states

> the git push command doesn’t transfer tags to remote servers

But the NOTE further down incorrectly states `git push`  pushes both light weight and annotated tags to the server.
99% sure this is a typo, where `git push origin <tagname>` is the command intended

This PR makes that change
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
