### PR TITLE
fix: update text in git-enforced policy file

### DIFF
--- a/book/08-customizing-git/sections/policy.asc
+++ b/book/08-customizing-git/sections/policy.asc
@@ -123,7 +123,7 @@ In this case, you have a couple of administrators, some documentation writers wi
 
 [source]
 ----
-avail|nickh,pjhyett,defunkt,tpw
+avail|nickh,pjhyett,defunkt,tpw|nil
 avail|usinclair,cdickens,ebronte|doc
 avail|schacon|lib
 avail|schacon|tests


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- update text in book/08-customizing-git/sections/policy.asc file (missing `nil` directory in ACL file)

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
