### PR TITLE
Add documentation link validation workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,0 +1,70 @@
+name: Documentation Validation
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - '**/*.md'
+      - '**/*.markdown'
+      - '**/*.asc'
+      - '**/*.adoc'
+      - '.github/workflows/docs-validation.yml'
+      - '.docs-validator.toml'
+
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - '**/*.md'
+      - '**/*.markdown'
+      - '**/*.asc'
+      - '**/*.adoc'
+      - '.github/workflows/docs-validation.yml'
+      - '.docs-validator.toml'
+
+  workflow_dispatch:
+    inputs:
+      target_path:
+        description: 'Path to scan'
+        required: false
+        default: '.'
+      fail_on_error:
+        description: 'Fail pipeline on errors'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  validate-docs:
+    name: Validate Documentation Links
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install docs-validator
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/Nokhrin/docs-validator.git
+
+      - name: Run documentation validation
+        run: |
+          FAIL_FLAG=""
+          if [ "${{ github.event.inputs.fail_on_error }}" = "true" ] || [ -z "${{ github.event.inputs.fail_on_error }}" ]; then
+            FAIL_FLAG="--fail-on-error"
+          fi
+          TARGET_PATH="${{ github.event.inputs.target_path || '.' }}"
+          docs-validator scan "$TARGET_PATH" --validate $FAIL_FLAG --report markdown --output docs-validation-report.md
+
+      - name: Upload validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-validation-report
+          path: docs-validation-report.md
+          retention-days: 7


### PR DESCRIPTION
This PR adds automated documentation link validation to the progit2 repository using the docs-validator tool.

## What was done

- Integrated documentation link validation into the CI/CD pipeline
- Configured automated scanning of all AsciiDoc documentation files
- Generated comprehensive validation reports in Markdown format
- Uploaded validation reports as artifacts for review

## Validation Results

https://github.com/Nokhrin/progit2/actions/runs/27497642111/job/81275058615

The initial validation scan identified:
- **50 errors** - Broken external links that need attention
- **142 warnings** - Files without incoming links and links requiring manual verification
- **113 files** scanned across the entire documentation
- **260 external links** checked (83 broken)
- **6 internal links** checked (all valid)

## Benefits

1. **Improved documentation quality**: Catches broken links before they reach readers
2. **Automated quality control**: Runs on every push and pull request
3. **Actionable reports**: Detailed Markdown reports uploaded as artifacts
4. **Early detection**: Identifies link rot and structural issues proactively
5. **Maintainability**: Helps maintain documentation integrity over time

## Key findings

Most errors are in external GitHub repository links that no longer exist (e.g., old grit repositories, example projects). The validation also identified many files that are not linked from other documentation pages, which may need better navigation structure.

The full validation report is available in the workflow artifacts for detailed review.

---

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).