### PR TITLE
Fix broken links in Pro Git book

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -364,7 +364,7 @@ When a topic branch has finally been merged into `master`, it's removed from the
 The Git project also has a `maint` branch that is forked off from the last release to provide backported patches in case a maintenance release is required.
 Thus, when you clone the Git repository, you have four branches that you can check out to evaluate the project in different stages of development, depending on how cutting edge you want to be or how you want to contribute; and the maintainer has a structured workflow to help them vet new contributions.
 The Git project's workflow is specialized.
-To clearly understand this you could check out the https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt[Git Maintainer's guide^].
+To clearly understand this you could check out the https://github.com/git/git/blob/master/Documentation/howto/maintain-git.adoc[Git Maintainer's guide^].
 
 [[_rebase_cherry_pick]]
 ===== Rebasing and Cherry-Picking Workflows

--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -233,5 +233,5 @@ pygit2.Repository("/path/to/repo") # open repository
 ==== Further Reading
 
 Of course, a full treatment of Libgit2's capabilities is outside the scope of this book.
-If you want more information on Libgit2 itself, there's API documentation at https://libgit2.github.com/libgit2[^], and a set of guides at https://libgit2.github.com/docs[^].
+If you want more information on Libgit2 itself, there's API documentation at https://libgit2.org/docs/reference/main/[^], and a set of guides at https://libgit2.org/docs/[^].
 For the other bindings, check the bundled README and tests; there are often small tutorials and pointers to further reading there.


### PR DESCRIPTION
Fixes #2063

Updates broken links in the Pro Git book:

- `maintain-git.txt` -> `maintain-git.adoc`
- old `libgit2.github.com` documentation links -> current `libgit2.org` documentation links